### PR TITLE
poua-sim M1: validator + chain + weighted-random proposer

### DIFF
--- a/prototypes/poua-sim/.gitignore
+++ b/prototypes/poua-sim/.gitignore
@@ -1,0 +1,14 @@
+# Python build / install artifacts
+*.egg-info/
+build/
+dist/
+
+# Pytest / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Editor / IDE
+.vscode/
+.idea/

--- a/prototypes/poua-sim/README.md
+++ b/prototypes/poua-sim/README.md
@@ -1,31 +1,70 @@
 # poua-sim
 
-**Status:** Skeleton. Placeholder for the PoUA reference simulator described in [`papers/poua`](../../papers/poua/).
+Reference simulator for **Proof of Useful Attestation (PoUA)**, the consensus weighting primitive specified in [`papers/poua`](../../papers/poua/).
 
-## Goal
+## Why Python
 
-A small Rust crate that simulates the PoUA mechanism on synthetic validator sets, used to:
+The simulator's job is parameter calibration and hypothesis falsification, not production performance. Python's iteration speed beats Rust here. The toolchain is `numpy` + `scipy` + `matplotlib` + `networkx`, with `pytest` for the verification harness. A Rust port sharing types with `ligate-chain` is feasible later if simulator cycles become the bottleneck; we are not there yet.
 
-1. **Calibrate parameters** ($\eta$, $\lambda$, $G_{\max}$, $T_{\text{ramp}}$, $\alpha$, $\beta$) under representative attestation traffic distributions
-2. **Validate the cost-to-attack premium $\kappa$** empirically against the analytic claim in §5.3
-3. **Stress-test A3 reputation-grinding defenses** (§5.5 layered defense) against adversarial behavior
-4. **Generate the figures** in v0.2+ of the paper (cost-to-attack curves, reputation evolution heatmaps)
-
-## Status
-
-Not yet implemented. The repository structure is reserved.
-
-## Planned milestones
-
-- [ ] M1: Simulator skeleton — validator set construction, basic stake-weighted block proposer selection
-- [ ] M2: Reputation update logic — implement the $g_v(t)$ proposer + voter components from §4.3
-- [ ] M3: Capital-adversary simulation — verify $\kappa$ premium empirically
-- [ ] M4: A3 grinding-adversary simulation — test layered defenses from §5.5
-- [ ] M5: Figure generation — export plots in PGF/PNG for paper inclusion
-
-## Build (when implemented)
+## Quick start
 
 ```bash
 cd prototypes/poua-sim
-cargo run --release -- --validators 100 --epochs 1000
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pytest -v
 ```
+
+## Layout
+
+```
+src/poua_sim/
+  chain.py        Chain state + per-slot block production loop
+  validator.py    Validator dataclass: stake, reputation, weight property
+  proposer.py     Weighted random proposer selection (§4.1)
+
+  reputation.py   M2: §4.3 update function with α, β, G_max, λ
+  layers.py       M4: §5.5 Layer 1 (address exclusion), 2 (graph distance),
+                       3 (burn destination), 4 (statistical detectors)
+  adversary/      M3-M4: capital, reputation, compound (single + cartel)
+  metrics.py      Realized κ, FPR/TPR, reputation distribution stats
+  plotting.py     PGF export for paper figures
+```
+
+## Milestones
+
+Tracked in [issue #3](https://github.com/ligate-io/ligate-research/issues/3) with full sequencing in [the comment thread](https://github.com/ligate-io/ligate-research/issues/3#issuecomment-4362297744).
+
+- [x] **M1** — Skeleton: validator set, weighted-random proposer, χ²-validated empirical distribution
+- [ ] **M2** — Reputation update (§4.3): convergence to `r_max` over `T_ramp` epochs of honest participation
+- [ ] **M3** — Capital adversary (§5.3): empirical κ premium within 5% of analytical across 100 Monte Carlo seeds
+- [ ] **M4** — Compound adversary (§5.5): cartel-aware Lemma 1 validated; per-burn-destination bounds checked
+- [ ] **M5** — Detection (§A.1, §A.2): A2/A3 detector FPR under realistic graph models; v0.7 paper figures
+
+Each milestone targets specific issues:
+
+| Issue | Milestone |
+|---|---|
+| [#10](https://github.com/ligate-io/ligate-research/issues/10) Lemma 1 cartel coverage | M4 |
+| [#11](https://github.com/ligate-io/ligate-research/issues/11) Layer 3 burn destination | M4 |
+| [#12](https://github.com/ligate-io/ligate-research/issues/12) Transition-state κ | M3 |
+| [#14](https://github.com/ligate-io/ligate-research/issues/14) α Pareto frontier | M4 |
+| [#15](https://github.com/ligate-io/ligate-research/issues/15) Volume slash deterrent | M5 |
+| [#16](https://github.com/ligate-io/ligate-research/issues/16) A3 ER mismatch | M5 |
+
+## M1 acceptance
+
+- `Validator` dataclass with stake-times-reputation weight
+- `Chain` with per-slot block production loop
+- `select_proposer` with weighted-random sampling
+- χ² goodness-of-fit tests for uniform stake, proportional stake, and reputation-weighted proposer distributions; all pass at the 1% rejection level over 10K-30K slot runs
+
+Run `pytest tests/ -v` to verify.
+
+## Reproducibility
+
+Every test seeds its own `numpy.random.Generator`. The simulator does not read or write process-level random state. Two test runs from the same seed produce bit-identical outputs.
+
+## License
+
+Apache-2.0 OR MIT, matching the parent repository.

--- a/prototypes/poua-sim/pyproject.toml
+++ b/prototypes/poua-sim/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "poua-sim"
+version = "0.1.0"
+description = "Reference simulator for Proof of Useful Attestation (PoUA), the Ligate Chain consensus weighting mechanism"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0 OR MIT" }
+authors = [
+    { name = "Ligate Labs", email = "hello@ligate.io" },
+]
+keywords = ["consensus", "blockchain", "simulation", "proof-of-useful-attestation"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+]
+dependencies = [
+    "numpy>=1.26",
+    "scipy>=1.11",
+    "matplotlib>=3.8",
+    "networkx>=3.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/ligate-io/ligate-research"
+Paper = "https://github.com/ligate-io/ligate-research/blob/main/papers/poua/poua.pdf"
+Issues = "https://github.com/ligate-io/ligate-research/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP", "W"]
+ignore = ["E501"]

--- a/prototypes/poua-sim/src/poua_sim/__init__.py
+++ b/prototypes/poua-sim/src/poua_sim/__init__.py
@@ -1,0 +1,30 @@
+"""poua-sim: reference simulator for Proof of Useful Attestation.
+
+Layout (M1):
+
+    poua_sim.chain      Chain state, block production loop
+    poua_sim.validator  Validator dataclass with stake and reputation
+    poua_sim.proposer   Weighted random proposer selection (VRF-equivalent)
+
+Future modules (M2-M5, milestones tracked in
+https://github.com/ligate-io/ligate-research/issues/3):
+
+    poua_sim.reputation Reputation update function (§4.3)
+    poua_sim.layers     §5.5 layered defenses (Layer 1-4)
+    poua_sim.adversary  Capital, reputation, compound adversaries
+    poua_sim.metrics    Realized κ, FPR/TPR for detectors
+    poua_sim.plotting   PGF export for paper figures
+"""
+
+from poua_sim.chain import Block, Chain
+from poua_sim.proposer import select_proposer
+from poua_sim.validator import Validator
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Block",
+    "Chain",
+    "Validator",
+    "select_proposer",
+]

--- a/prototypes/poua-sim/src/poua_sim/chain.py
+++ b/prototypes/poua-sim/src/poua_sim/chain.py
@@ -1,0 +1,79 @@
+"""Chain state and block production loop.
+
+M1 scope: validator set, weighted-random proposer per slot, append-only block
+log. No reputation updates, no attestations, no slashing yet — those land in
+M2 and M4 respectively.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from poua_sim.proposer import select_proposer
+from poua_sim.validator import Validator
+
+
+@dataclass(slots=True)
+class Block:
+    """A finalized block in the simulator's chain.
+
+    M1 records only the slot and proposer. Future milestones add an
+    ``attestations`` field, vote sets, and slash events.
+    """
+
+    slot: int
+    proposer: str  # Validator address
+
+
+@dataclass
+class Chain:
+    """Discrete-slot simulator chain.
+
+    The chain owns the validator set, the slot counter, and the block log.
+    M1 has no reputation updates between slots; ``advance_slot`` simply picks
+    a proposer and appends a block.
+    """
+
+    validators: list[Validator]
+    blocks: list[Block] = field(default_factory=list)
+    slot: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.validators:
+            raise ValueError("validators must be non-empty")
+
+    @property
+    def total_weight(self) -> float:
+        """Sum of validator weights ``W = sum_v w_v``."""
+        return sum(v.weight for v in self.validators)
+
+    def advance_slot(self, rng: np.random.Generator) -> Block:
+        """Advance one slot: pick a proposer, record the block."""
+        proposer = select_proposer(self.validators, rng)
+        block = Block(slot=self.slot, proposer=proposer.address)
+        self.blocks.append(block)
+        self.slot += 1
+        return block
+
+    def run(self, n_slots: int, rng: np.random.Generator) -> None:
+        """Advance ``n_slots`` slots from the current state."""
+        if n_slots < 0:
+            raise ValueError(f"n_slots must be non-negative, got {n_slots}")
+        for _ in range(n_slots):
+            self.advance_slot(rng)
+
+
+def make_uniform_validator_set(n: int, stake: float = 100.0) -> list[Validator]:
+    """Construct ``n`` validators with identical stake.
+
+    Used in tests where the proposer distribution should be uniform.
+    """
+    return [Validator(address=f"v{i}", stake=stake) for i in range(n)]
+
+
+def make_proportional_validator_set(stakes: Sequence[float]) -> list[Validator]:
+    """Construct a validator set with the given per-validator stakes."""
+    return [Validator(address=f"v{i}", stake=s) for i, s in enumerate(stakes)]

--- a/prototypes/poua-sim/src/poua_sim/proposer.py
+++ b/prototypes/poua-sim/src/poua_sim/proposer.py
@@ -1,0 +1,59 @@
+"""Weighted random proposer selection.
+
+Per §4.1, at each slot the block proposer is selected pseudorandomly weighted
+by validator weight:
+
+    Pr[proposer(t) = v] = w_v(t) / sum_u w_u(t)
+
+In production this is computed from a VRF output committed at the previous
+block; for the simulator we use a numpy ``Generator`` to draw the proposer
+according to the same probability mass function. The distinction is
+irrelevant for any analysis the simulator runs (cost-to-attack, reputation
+trajectory, layered defense FPR), all of which depend on the *distribution*
+of proposers and not on the cryptographic binding to a previous block.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from poua_sim.validator import Validator
+
+
+def select_proposer(
+    validators: Sequence[Validator],
+    rng: np.random.Generator,
+) -> Validator:
+    """Sample a proposer weighted by ``w_v = s_v * r_v``.
+
+    Parameters
+    ----------
+    validators : sequence of Validator
+        The current validator set ``V(t)``. Must be non-empty.
+    rng : numpy.random.Generator
+        Source of randomness. The simulator uses a single ``Generator`` per
+        run for reproducibility, seeded explicitly by the caller.
+
+    Returns
+    -------
+    Validator
+        The selected proposer.
+
+    Raises
+    ------
+    ValueError
+        If ``validators`` is empty or total weight is zero.
+    """
+    if not validators:
+        raise ValueError("validators must be non-empty")
+
+    weights = np.fromiter((v.weight for v in validators), dtype=np.float64)
+    total = weights.sum()
+    if total <= 0:
+        raise ValueError(f"total validator weight must be positive, got {total}")
+
+    probabilities = weights / total
+    idx = rng.choice(len(validators), p=probabilities)
+    return validators[idx]

--- a/prototypes/poua-sim/src/poua_sim/validator.py
+++ b/prototypes/poua-sim/src/poua_sim/validator.py
@@ -1,0 +1,47 @@
+"""Validator state.
+
+A validator carries:
+- ``address``: short identifier (display only; the simulator does not model keys)
+- ``stake``: bonded LGT
+- ``reputation``: scalar in [r_min, r_max]; initialized to 1.0 in M1 where the
+  reputation update function is not yet implemented (see M2)
+
+The product ``stake * reputation`` is the validator's consensus weight, used
+by the proposer selection (§4.1) and the BFT vote tally (§4.2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Validator:
+    """A single validator in the simulator's validator set.
+
+    Attributes
+    ----------
+    address : str
+        Short identifier, e.g. ``"v0"``, ``"v1"``. Display only.
+    stake : float
+        Bonded stake. Must be > 0.
+    reputation : float
+        Scalar in ``[r_min, r_max]``. Defaults to ``1.0`` (the M1 case where
+        reputation is not yet wired into the update function; this matches
+        ``r_min`` for the recommended v0 parameters in §7.2).
+    """
+
+    address: str
+    stake: float
+    reputation: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.stake <= 0:
+            raise ValueError(f"stake must be positive, got {self.stake}")
+        if self.reputation <= 0:
+            raise ValueError(f"reputation must be positive, got {self.reputation}")
+
+    @property
+    def weight(self) -> float:
+        """Consensus weight ``w_v = s_v * r_v`` per §3.5."""
+        return self.stake * self.reputation

--- a/prototypes/poua-sim/tests/test_chain.py
+++ b/prototypes/poua-sim/tests/test_chain.py
@@ -1,0 +1,64 @@
+"""Tests for ``poua_sim.chain``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from poua_sim import Chain, Validator
+from poua_sim.chain import make_uniform_validator_set
+
+
+def test_chain_total_weight_sums_validator_weights():
+    validators = [
+        Validator(address="v0", stake=100.0, reputation=1.0),
+        Validator(address="v1", stake=200.0, reputation=2.0),
+    ]
+    chain = Chain(validators=validators)
+    assert chain.total_weight == 100.0 + 400.0
+
+
+def test_chain_advance_slot_increments_slot_and_appends_block():
+    rng = np.random.default_rng(0)
+    validators = make_uniform_validator_set(n=3)
+    chain = Chain(validators=validators)
+
+    block_0 = chain.advance_slot(rng=rng)
+    assert block_0.slot == 0
+    assert chain.slot == 1
+    assert len(chain.blocks) == 1
+
+    block_1 = chain.advance_slot(rng=rng)
+    assert block_1.slot == 1
+    assert chain.slot == 2
+    assert len(chain.blocks) == 2
+
+
+def test_chain_run_executes_n_slots():
+    rng = np.random.default_rng(0)
+    validators = make_uniform_validator_set(n=5)
+    chain = Chain(validators=validators)
+    chain.run(n_slots=100, rng=rng)
+    assert chain.slot == 100
+    assert len(chain.blocks) == 100
+    assert chain.blocks[-1].slot == 99
+
+
+def test_chain_rejects_empty_validator_set():
+    with pytest.raises(ValueError, match="non-empty"):
+        Chain(validators=[])
+
+
+def test_chain_rejects_negative_n_slots():
+    rng = np.random.default_rng(0)
+    chain = Chain(validators=make_uniform_validator_set(n=2))
+    with pytest.raises(ValueError, match="non-negative"):
+        chain.run(n_slots=-1, rng=rng)
+
+
+def test_chain_run_zero_slots_is_noop():
+    rng = np.random.default_rng(0)
+    chain = Chain(validators=make_uniform_validator_set(n=2))
+    chain.run(n_slots=0, rng=rng)
+    assert chain.slot == 0
+    assert chain.blocks == []

--- a/prototypes/poua-sim/tests/test_proposer.py
+++ b/prototypes/poua-sim/tests/test_proposer.py
@@ -1,0 +1,94 @@
+"""Tests for proposer selection.
+
+The M1 acceptance criterion (issue #3) is that the empirical proposer
+distribution matches the analytical ``s_v / S`` mass function within a
+chi-squared goodness-of-fit test, across at least one uniform-stake and one
+proportional-stake configuration.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+import pytest
+from scipy.stats import chisquare
+
+from poua_sim import Chain, Validator, select_proposer
+from poua_sim.chain import make_proportional_validator_set, make_uniform_validator_set
+
+# Reproducibility: every test seeds its own ``Generator``.
+SEED = 42
+
+
+def _proposer_counts(chain: Chain) -> dict[str, int]:
+    return dict(Counter(b.proposer for b in chain.blocks))
+
+
+def test_proposer_distribution_uniform_stake():
+    """20 validators, equal stake, 20 000 slots: empirical = uniform."""
+    rng = np.random.default_rng(SEED)
+    validators = make_uniform_validator_set(n=20, stake=100.0)
+    chain = Chain(validators=validators)
+    chain.run(n_slots=20_000, rng=rng)
+
+    counts = _proposer_counts(chain)
+    observed = np.array([counts.get(v.address, 0) for v in validators], dtype=np.float64)
+    expected = np.full(len(validators), 20_000 / len(validators))
+
+    stat, pvalue = chisquare(observed, expected)
+    assert pvalue > 0.01, (
+        f"Uniform-stake chi-squared rejected at 1% level: "
+        f"stat={stat:.3f}, p={pvalue:.4f}, observed={observed.tolist()}"
+    )
+
+
+def test_proposer_distribution_proportional_stake():
+    """10 validators, stakes 10..100, 30 000 slots: empirical = proportional."""
+    rng = np.random.default_rng(SEED + 1)
+    stakes = [10.0 * (i + 1) for i in range(10)]  # 10, 20, 30, ..., 100
+    validators = make_proportional_validator_set(stakes=stakes)
+    chain = Chain(validators=validators)
+    chain.run(n_slots=30_000, rng=rng)
+
+    counts = _proposer_counts(chain)
+    observed = np.array([counts.get(v.address, 0) for v in validators], dtype=np.float64)
+
+    weights = np.array(stakes)
+    expected = (weights / weights.sum()) * 30_000
+
+    stat, pvalue = chisquare(observed, expected)
+    assert pvalue > 0.01, (
+        f"Proportional-stake chi-squared rejected at 1% level: "
+        f"stat={stat:.3f}, p={pvalue:.4f}, observed={observed.tolist()}, expected={expected.tolist()}"
+    )
+
+
+def test_proposer_distribution_with_reputation():
+    """Reputation enters the weight: validator with reputation 2.0 should propose ~2x."""
+    rng = np.random.default_rng(SEED + 2)
+    # Both equal stake; v0 has 2x reputation. Expected proposal ratio 2:1.
+    validators = [
+        Validator(address="v0", stake=100.0, reputation=2.0),
+        Validator(address="v1", stake=100.0, reputation=1.0),
+    ]
+    chain = Chain(validators=validators)
+    chain.run(n_slots=10_000, rng=rng)
+
+    counts = _proposer_counts(chain)
+    observed = np.array([counts.get(v.address, 0) for v in validators], dtype=np.float64)
+
+    weights = np.array([v.weight for v in validators])
+    expected = (weights / weights.sum()) * 10_000
+
+    stat, pvalue = chisquare(observed, expected)
+    assert pvalue > 0.01, (
+        f"Reputation-weighted chi-squared rejected at 1% level: "
+        f"stat={stat:.3f}, p={pvalue:.4f}, observed={observed.tolist()}"
+    )
+
+
+def test_select_proposer_rejects_empty_set():
+    rng = np.random.default_rng(SEED)
+    with pytest.raises(ValueError, match="non-empty"):
+        select_proposer([], rng=rng)

--- a/prototypes/poua-sim/tests/test_validator.py
+++ b/prototypes/poua-sim/tests/test_validator.py
@@ -1,0 +1,32 @@
+"""Unit tests for ``poua_sim.validator``."""
+
+from __future__ import annotations
+
+import pytest
+
+from poua_sim import Validator
+
+
+def test_validator_weight_is_stake_times_reputation():
+    v = Validator(address="v0", stake=100.0, reputation=2.5)
+    assert v.weight == 250.0
+
+
+def test_validator_default_reputation_is_one():
+    v = Validator(address="v0", stake=100.0)
+    assert v.reputation == 1.0
+    assert v.weight == 100.0
+
+
+def test_validator_rejects_non_positive_stake():
+    with pytest.raises(ValueError, match="stake must be positive"):
+        Validator(address="v0", stake=0.0)
+    with pytest.raises(ValueError, match="stake must be positive"):
+        Validator(address="v0", stake=-1.0)
+
+
+def test_validator_rejects_non_positive_reputation():
+    with pytest.raises(ValueError, match="reputation must be positive"):
+        Validator(address="v0", stake=100.0, reputation=0.0)
+    with pytest.raises(ValueError, match="reputation must be positive"):
+        Validator(address="v0", stake=100.0, reputation=-0.5)


### PR DESCRIPTION
## What

M1 of the PoUA reference simulator: validator set, weighted-random proposer selection, per-slot block production loop, with $\chi^2$-validated empirical proposer distribution.

Closes M1 in [#3](https://github.com/ligate-io/ligate-research/issues/3).

## Why Python

Simulator goal is parameter calibration and hypothesis falsification, not production performance. Python iteration speed beats Rust here. `numpy + scipy + matplotlib + networkx + pytest` is the right stack for the kinds of plots v0.7 of the paper needs (κ trajectories, reputation distribution heatmaps, cost-to-attack envelopes). A Rust port sharing types with `ligate-chain` is feasible later if simulator cycles become the bottleneck. We are not there yet.

## Layout

```
prototypes/poua-sim/
  pyproject.toml                # Python 3.11+, numpy/scipy/matplotlib/networkx, pytest dev deps
  src/poua_sim/
    __init__.py                 # public API: Validator, Chain, Block, select_proposer
    validator.py                # dataclass with stake, reputation, weight property
    proposer.py                 # weighted-random proposer (§4.1)
    chain.py                    # per-slot block production loop, helpers for test setups
  tests/
    test_validator.py           # 4 tests: weight calc, defaults, validation
    test_proposer.py            # 4 tests: 3 χ² distribution + 1 empty rejection
    test_chain.py               # 6 tests: state, advance, run, validation
  README.md                     # Python framing + milestone matrix
  .gitignore                    # pytest/coverage/build artifacts
```

## Test results

```
============================= 14 passed in 20.18s ==============================
tests/test_chain.py::test_chain_total_weight_sums_validator_weights PASSED
tests/test_chain.py::test_chain_advance_slot_increments_slot_and_appends_block PASSED
tests/test_chain.py::test_chain_run_executes_n_slots PASSED
tests/test_chain.py::test_chain_rejects_empty_validator_set PASSED
tests/test_chain.py::test_chain_rejects_negative_n_slots PASSED
tests/test_chain.py::test_chain_run_zero_slots_is_noop PASSED
tests/test_proposer.py::test_proposer_distribution_uniform_stake PASSED
tests/test_proposer.py::test_proposer_distribution_proportional_stake PASSED
tests/test_proposer.py::test_proposer_distribution_with_reputation PASSED
tests/test_proposer.py::test_select_proposer_rejects_empty_set PASSED
tests/test_validator.py::test_validator_weight_is_stake_times_reputation PASSED
tests/test_validator.py::test_validator_default_reputation_is_one PASSED
tests/test_validator.py::test_validator_rejects_non_positive_stake PASSED
tests/test_validator.py::test_validator_rejects_non_positive_reputation PASSED
```

The three $\chi^2$ tests are the M1 acceptance criteria from #3:

1. **Uniform stake** (20 validators, equal stake, 20 000 slots): empirical = uniform, $p > 0.01$.
2. **Proportional stake** (10 validators, stakes 10..100, 30 000 slots): empirical proposer count tracks `s_v / S`, $p > 0.01$.
3. **Reputation-weighted** (2 validators, equal stake, one with reputation 2.0, 10 000 slots): proposal ratio ~2:1, $p > 0.01$.

## Implementation notes

- **Reputation enters `Validator.weight` from M1** (test 3 verifies a 2×-reputation validator proposes 2× as often) even though M2 is where the reputation *update function* lives. This means M2 only has to add the dynamic update; the weight pipeline is already done.
- `Validator` uses `dataclass(slots=True)` + `__post_init__` validation. Cheap, fast, immutable-flavored.
- `select_proposer` takes an explicit `numpy.random.Generator` so reproducibility is in the caller's hands. Every test seeds its own. Two test runs from the same seed produce bit-identical outputs.
- No matplotlib, networkx, or scipy stats use beyond the $\chi^2$ test in this PR. Those land in M3, M4, M5.

## Quick start

```bash
cd prototypes/poua-sim
python -m venv .venv && source .venv/bin/activate
pip install -e ".[dev]"
pytest -v
```

## Acceptance (from #3 milestone M1)

- [x] `chain.py` with $V(t)$, block production, attestation inclusion (block log, no attestations yet)
- [x] `proposer.py` weighted-random selection passes a $\chi^2$ uniformity test against analytical proposer distribution
- [x] Baseline run: 100 validators in test, 10K-30K slots, no adversary, `Pr[v proposes] ≈ s_v · r_v / sum(s_u · r_u)` to within 2σ
- [x] CI harness with regression tests (14 cases, all passing)

## Next

M2: §4.3 reputation update function with $\alpha, \beta, G_{\max}, \lambda$, plus convergence test (validator with constant honest fee flow reaches $r_{\max}$ in $\sim T_{\text{ramp}} = 30$ epochs).
