### PR TITLE
poua-sim: cross-language test vectors for §4.3, §5.3, §5.5.3

### DIFF
--- a/prototypes/poua-sim/README.md
+++ b/prototypes/poua-sim/README.md
@@ -114,6 +114,26 @@ Note for v0.7 paper: the v0.6 Lemma 1 proof uses `α_eff = α + mβ/k` (assumes 
 
 Run `pytest tests/ -v` to verify (113 tests). Run `python scripts/run_*.py` to regenerate figures.
 
+## Cross-language test vectors
+
+`test_vectors/` holds JSON encoding of the simulator's analytical truths,
+keyed by paper section. The Python harness in `tests/test_test_vectors.py`
+re-runs the simulator's implementation against each vector and asserts the
+output matches expected within stated tolerance. A future Rust consumer in
+`ligate-chain` reads the same files and runs the same checks.
+
+If a paper claim changes, the workflow is:
+
+1. Update the analytical function in `poua_sim`.
+2. Re-run `python scripts/generate_test_vectors.py`.
+3. Both the Python and the Rust harness fail at the changed claim if either
+   implementation drifted.
+
+This is the structural fix from
+[ligate-research#23](https://github.com/ligate-io/ligate-research/issues/23):
+claim-vs-implementation drift becomes impossible without a CI failure in
+whichever repo lags. See `test_vectors/README.md` for the format spec.
+
 ## Open follow-ups
 
 - **Lemma 1 paper reconciliation** ([#22](https://github.com/ligate-io/ligate-research/pull/22), merged): the v0.6 proof and §4.3 disagreed on whether the proposer earns voter-channel reputation on its own block. Simulator implements §4.3 strictly and produced the empirical bound that flagged the inconsistency. v0.6.1 patched the proof to match.

--- a/prototypes/poua-sim/scripts/generate_test_vectors.py
+++ b/prototypes/poua-sim/scripts/generate_test_vectors.py
@@ -1,0 +1,249 @@
+"""Generate cross-language test vectors for PoUA mechanisms.
+
+Each vector is one (inputs, expected) pair derived from a simulator
+analytical function. Both the Python simulator and any future production
+implementation consume the same JSON files and check their output matches.
+
+Run:
+
+    python scripts/generate_test_vectors.py
+
+Outputs land in `test_vectors/*.json`. Re-run after any change to the
+analytical functions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from poua_sim import (
+    BurnDestination,
+    Layer3Config,
+    ReputationParams,
+    Validator,
+    alpha_eff,
+    analytical_attack_stake,
+    apply_reputation_update,
+    layer3_net_burn,
+)
+
+OUT = Path(__file__).resolve().parent.parent / "test_vectors"
+OUT.mkdir(exist_ok=True)
+
+
+# --- §4.3 reputation update -------------------------------------------
+
+
+def gen_reputation_update_vectors() -> dict:
+    """§4.3: r_v(t+E) = clip_{[r_min, r_max]}(r_v + η·g_v - λ·b_v)."""
+    p = ReputationParams()
+    cases = []
+
+    def case(name: str, description: str, r: float, g_v: float, b_v: float):
+        v = Validator(address="v0", stake=100.0, reputation=r)
+        out = apply_reputation_update(v, p, g_v=g_v, b_v=b_v)
+        cases.append({
+            "name": name,
+            "description": description,
+            "paper_reference": "§4.3",
+            "inputs": {
+                "reputation": r,
+                "g_v": g_v,
+                "b_v": b_v,
+                "eta": p.eta,
+                "lambda": p.lambda_,
+                "r_min": p.r_min,
+                "r_max": p.r_max,
+            },
+            "expected": {"reputation_next": out},
+            "tolerance": {"absolute": 1e-9},
+        })
+
+    case("zero-input-no-change", "g_v=0, b_v=0 leaves reputation unchanged", r=4.0, g_v=0.0, b_v=0.0)
+    case("growth-saturated", "g_v=g_max yields η·g_max per epoch growth", r=1.0, g_v=p.g_max, b_v=0.0)
+    case("clip-to-r_max", "huge g_v clips at r_max", r=7.5, g_v=1e6, b_v=0.0)
+    case("clip-to-r_min", "huge slash clips at r_min", r=8.0, g_v=0.0, b_v=1e6)
+    case("net-with-growth-and-slash",
+         "growth η·g_max canceled by partial slash",
+         r=4.0, g_v=p.g_max, b_v=p.eta * p.g_max / p.lambda_)
+    case("severe-slash-from-r_max",
+         "severity = (r_max - r_min)/λ + (η·g_max)/λ takes r_max → r_min under full participation",
+         r=p.r_max, g_v=p.g_max,
+         b_v=(p.r_max - p.r_min) / p.lambda_ + p.eta * p.g_max / p.lambda_)
+
+    return {"vectors": cases}
+
+
+# --- §5.5.3 α_eff ----------------------------------------------------
+
+
+def gen_alpha_eff_vectors() -> dict:
+    """§5.5.3: α_eff(α, β, m, k) = α + (m-1)·β/k."""
+    cases = []
+
+    def case(name: str, description: str, alpha: float, beta: float, m: int, k: int):
+        out = alpha_eff(alpha=alpha, beta=beta, m=m, k=k)
+        cases.append({
+            "name": name,
+            "description": description,
+            "paper_reference": "§5.5.3 (Lemma 1 v0.6.1)",
+            "inputs": {"alpha": alpha, "beta": beta, "m": m, "k": k},
+            "expected": {"alpha_eff": out},
+            "tolerance": {"absolute": 1e-9},
+        })
+
+    case("single-proposer", "m=1 recovers α exactly", 0.7, 0.3, 1, 10)
+    case("byzantine-cartel-small-k", "m=k/3 finite-k case (k=12)", 0.7, 0.3, 4, 12)
+    case("byzantine-cartel-mainnet-k", "m=k/3 with k=99 close to asymptotic", 0.7, 0.3, 33, 99)
+    case("full-cartel-network", "m=k = whole network", 0.7, 0.3, 10, 10)
+    case("alpha-half-byzantine", "α=0.5, β=0.5 widens cartel discount", 0.5, 0.5, 4, 12)
+    case("alpha-high-byzantine", "α=0.9, β=0.1 shrinks cartel discount", 0.9, 0.1, 4, 12)
+    case("proposer-only-extreme", "α=1.0, β=0.0 (no voter channel) at m=k", 1.0, 0.0, 5, 5)
+
+    return {"vectors": cases}
+
+
+# --- §5.3 cost-to-attack ---------------------------------------------
+
+
+def gen_cost_to_attack_vectors() -> dict:
+    """§5.3: s_C = (ρ/(1-ρ)) · (W_H / r_min)."""
+    cases = []
+
+    def case(name: str, description: str, n_honest: int, stake: float,
+             reputation: float, target_rho: float, r_min: float):
+        honest = [
+            Validator(address=f"v{i}", stake=stake, reputation=reputation)
+            for i in range(n_honest)
+        ]
+        s_c = analytical_attack_stake(
+            target_rho=target_rho, honest_validators=honest, r_min=r_min
+        )
+        # Realized weight share when the adversary at r_min injects with stake s_c.
+        adversary_weight = s_c * r_min
+        honest_weight = sum(v.weight for v in honest)
+        rho_realized = adversary_weight / (adversary_weight + honest_weight)
+        cases.append({
+            "name": name,
+            "description": description,
+            "paper_reference": "§5.3",
+            "inputs": {
+                "n_honest": n_honest,
+                "stake_per_honest": stake,
+                "reputation_per_honest": reputation,
+                "target_rho": target_rho,
+                "r_min": r_min,
+            },
+            "expected": {
+                "attack_stake": s_c,
+                "rho_realized": rho_realized,
+            },
+            "tolerance": {"absolute": 1e-9},
+        })
+
+    case("pure-pos-rho-0.2", "κ=1 (all honest at r_min), target ρ=0.2",
+         n_honest=10, stake=100.0, reputation=1.0, target_rho=0.2, r_min=1.0)
+    case("kappa-8-rho-0.2", "honest at r_max=8, target ρ=0.2",
+         n_honest=10, stake=100.0, reputation=8.0, target_rho=0.2, r_min=1.0)
+    case("kappa-8-byzantine-threshold", "honest at r_max=8, target ρ=1/3 (BFT cap)",
+         n_honest=10, stake=100.0, reputation=8.0, target_rho=1 / 3, r_min=1.0)
+    case("kappa-4-rho-0.1", "honest at r=4, target ρ=0.1",
+         n_honest=20, stake=50.0, reputation=4.0, target_rho=0.1, r_min=1.0)
+
+    return {"vectors": cases}
+
+
+# --- §5.5.3 Lemma 1 cost-to-grind ----------------------------------
+
+
+def gen_lemma1_vectors() -> dict:
+    """§5.5.3: F_net per cartel member across burn destinations."""
+    cases = []
+
+    def case(name: str, description: str, alpha: float, beta: float, m: int, k: int,
+             tau_burn: float, eta: float, delta_r: float, destination: str,
+             adversary_stake_share: float = 0.0,
+             governance_recovery_rate: float = 0.0):
+        a_eff = alpha_eff(alpha=alpha, beta=beta, m=m, k=k)
+        # F_gross to gain delta_r per cartel member: gross_per_member = delta_r / (eta · alpha_eff)
+        gross_per_member = delta_r / (eta * a_eff)
+        config = Layer3Config(
+            tau_burn=tau_burn,
+            destination=BurnDestination(destination),
+            governance_recovery_rate=governance_recovery_rate,
+        )
+        f_net_per_member = layer3_net_burn(
+            gross_fees=gross_per_member,
+            config=config,
+            adversary_stake_share=adversary_stake_share,
+        )
+        cases.append({
+            "name": name,
+            "description": description,
+            "paper_reference": "§5.5.3 Lemma 1 (v0.6.1)",
+            "inputs": {
+                "alpha": alpha, "beta": beta, "m": m, "k": k,
+                "tau_burn": tau_burn, "eta": eta, "delta_r": delta_r,
+                "destination": destination,
+                "adversary_stake_share": adversary_stake_share,
+                "governance_recovery_rate": governance_recovery_rate,
+            },
+            "expected": {
+                "alpha_eff": a_eff,
+                "f_gross_per_member": gross_per_member,
+                "f_net_per_member": f_net_per_member,
+            },
+            "tolerance": {"absolute": 1e-9},
+        })
+
+    # Pure burn cases — match the §5.5.3 paper numerical example exactly.
+    case("single-pure-burn-v0",
+         "v0 params, single proposer, pure burn, full ramp",
+         alpha=0.7, beta=0.3, m=1, k=10, tau_burn=0.5,
+         eta=0.001, delta_r=7.0, destination="pure_burn")
+    case("byzantine-pure-burn-finite-k",
+         "v0 params, m=4 in k=12 (Byzantine cap finite)",
+         alpha=0.7, beta=0.3, m=4, k=12, tau_burn=0.5,
+         eta=0.001, delta_r=7.0, destination="pure_burn")
+    case("byzantine-pure-burn-mainnet-k",
+         "v0 params, m=33 in k=99 (close to asymptotic)",
+         alpha=0.7, beta=0.3, m=33, k=99, tau_burn=0.5,
+         eta=0.001, delta_r=7.0, destination="pure_burn")
+
+    # Treasury with 10% governance recovery — bound weakens by 10%.
+    case("byzantine-treasury-10pct",
+         "v0 params, m=4 k=12, treasury with 10% governance recovery",
+         alpha=0.7, beta=0.3, m=4, k=12, tau_burn=0.5,
+         eta=0.001, delta_r=7.0, destination="treasury",
+         governance_recovery_rate=0.1)
+
+    # Redistribution at Byzantine stake share — bound weakens by ρ_stake.
+    case("byzantine-redistribution-1third",
+         "v0 params, m=4 k=12, redistribution; adversary stake share 1/3",
+         alpha=0.7, beta=0.3, m=4, k=12, tau_burn=0.5,
+         eta=0.001, delta_r=7.0, destination="redistribution",
+         adversary_stake_share=1 / 3)
+
+    return {"vectors": cases}
+
+
+# --- main -----------------------------------------------------------
+
+
+def main() -> None:
+    files = {
+        "reputation_update.json": gen_reputation_update_vectors(),
+        "alpha_eff.json": gen_alpha_eff_vectors(),
+        "cost_to_attack.json": gen_cost_to_attack_vectors(),
+        "lemma1_cost_to_grind.json": gen_lemma1_vectors(),
+    }
+    for name, content in files.items():
+        path = OUT / name
+        path.write_text(json.dumps(content, indent=2) + "\n")
+        n = len(content["vectors"])
+        print(f"wrote {path} ({n} vectors)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/poua-sim/test_vectors/README.md
+++ b/prototypes/poua-sim/test_vectors/README.md
@@ -1,0 +1,122 @@
+# PoUA cross-language test vectors
+
+Shared JSON test cases that both the Python reference simulator and any
+production implementation (e.g. `ligate-chain` in Rust) consume to verify
+they implement the paper's mechanisms identically.
+
+The point is to make claim-vs-implementation drift impossible without a CI
+failure in whichever repo lags. This is the structural fix from
+[ligate-research#23](https://github.com/ligate-io/ligate-research/issues/23).
+
+## Why this matters
+
+`ligate-research/papers/poua/poua.md` v0.6 shipped with a Lemma 1 proof
+that quietly disagreed with §4.3 of the same paper. The simulator caught
+it during M2-M4 work because its tests check §4.3 literally; the proof's
+extra "proposer also votes on its own block" credit fell out as an
+empirical mismatch. We patched it as v0.6.1.
+
+That's the failure mode test vectors prevent. Each vector encodes one
+piece of analytical truth as `(inputs, expected outputs)`. If the paper's
+algebra changes, the vectors update. If the simulator's implementation
+drifts, the vector test fails. If `ligate-chain` implements the same
+mechanism, it consumes the same vectors and gets the same fail-fast
+guarantee.
+
+## File layout
+
+```
+test_vectors/
+├── README.md                   # this file
+├── schema.json                 # JSON schema for vectors (informal; documentation)
+├── reputation_update.json      # §4.3 r_v(t+E) = clip(r_v + η·g_v - λ·b_v)
+├── alpha_eff.json              # §5.5.3 α_eff(α, β, m, k) = α + (m-1)β/k
+├── cost_to_attack.json         # §5.3 s_C inversion + realized weight share
+└── lemma1_cost_to_grind.json   # §5.5.3 F_net per cartel member, per burn destination
+```
+
+## Vector format
+
+Each JSON file is `{"vectors": [...]}` where each vector is:
+
+```json
+{
+  "name": "single-validator-pure-burn",
+  "description": "m=1 cartel under pure burn, recommended v0 params",
+  "paper_reference": "§5.5.3 Lemma 1",
+  "inputs": {
+    "alpha": 0.7,
+    "beta": 0.3,
+    "m": 1,
+    "k": 10,
+    "tau_burn": 0.5,
+    "eta": 0.001,
+    "delta_r": 7.0,
+    "destination": "pure_burn",
+    "adversary_stake_share": 0.0
+  },
+  "expected": {
+    "alpha_eff": 0.7,
+    "f_net_per_member": 5000.0
+  },
+  "tolerance": {"absolute": 1e-9}
+}
+```
+
+Tolerance fields:
+- `"absolute"`: `|expected - actual| ≤ tol`
+- `"relative"`: `|expected - actual| / |expected| ≤ tol`
+- Either or both may be specified; checks pass if any specified bound holds.
+
+## Regenerating
+
+Vectors are produced by a generator script that calls the simulator's
+analytical functions and writes the outputs:
+
+```bash
+cd prototypes/poua-sim
+python scripts/generate_test_vectors.py
+```
+
+The generator is the source of truth. If a paper claim changes (e.g. a
+new `α_eff` formula), update the simulator's analytical function, regenerate
+vectors, and any consumer (Python here, future Rust) gets a clean test
+failure that points at the changed claim.
+
+## Consuming from another language
+
+A `ligate-chain` Rust consumer would parse the same JSON files and assert:
+
+```rust
+// Pseudocode
+let vectors: Vec<RepUpdateVector> = read_json("test_vectors/reputation_update.json");
+for v in vectors {
+    let actual = apply_reputation_update(v.inputs);
+    assert_within_tolerance(actual, v.expected, v.tolerance);
+}
+```
+
+The vector format is intentionally language-agnostic: only floats,
+ints, strings, and lists of those. No Python pickle, no Rust serde-specific
+extensions. Anything that can read JSON can consume them.
+
+## What the vectors cover
+
+| File | Claim |
+|---|---|
+| `reputation_update.json` | §4.3 reputation evolution at epoch boundaries |
+| `alpha_eff.json` | §5.5.3 cartel-aware effective proposer share |
+| `cost_to_attack.json` | §5.3 capital adversary stake inversion |
+| `lemma1_cost_to_grind.json` | §5.5.3 Lemma 1 across burn destinations |
+
+What the vectors do NOT cover:
+
+- Probabilistic outputs (proposer selection variance, statistical-detector FPR)
+  — these need Monte Carlo aggregation, not a single (input, expected) check.
+- Full chain-state evolution across many slots (covered by the integration
+  tests in `tests/test_chain_epochs.py`).
+- Layered defense Layer 1 / Layer 2 enforcement (covered by `tests/test_compound_adversary.py`).
+
+The vectors are about the **algebra**: when paper says `f(x) = y`, the
+simulator and the chain both compute `y` from `x`. If they disagree,
+something drifted.

--- a/prototypes/poua-sim/test_vectors/alpha_eff.json
+++ b/prototypes/poua-sim/test_vectors/alpha_eff.json
@@ -1,0 +1,123 @@
+{
+  "vectors": [
+    {
+      "name": "single-proposer",
+      "description": "m=1 recovers \u03b1 exactly",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 1,
+        "k": 10
+      },
+      "expected": {
+        "alpha_eff": 0.7
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-cartel-small-k",
+      "description": "m=k/3 finite-k case (k=12)",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 4,
+        "k": 12
+      },
+      "expected": {
+        "alpha_eff": 0.7749999999999999
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-cartel-mainnet-k",
+      "description": "m=k/3 with k=99 close to asymptotic",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 33,
+        "k": 99
+      },
+      "expected": {
+        "alpha_eff": 0.7969696969696969
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "full-cartel-network",
+      "description": "m=k = whole network",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 10,
+        "k": 10
+      },
+      "expected": {
+        "alpha_eff": 0.97
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "alpha-half-byzantine",
+      "description": "\u03b1=0.5, \u03b2=0.5 widens cartel discount",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.5,
+        "beta": 0.5,
+        "m": 4,
+        "k": 12
+      },
+      "expected": {
+        "alpha_eff": 0.625
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "alpha-high-byzantine",
+      "description": "\u03b1=0.9, \u03b2=0.1 shrinks cartel discount",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 0.9,
+        "beta": 0.1,
+        "m": 4,
+        "k": 12
+      },
+      "expected": {
+        "alpha_eff": 0.925
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "proposer-only-extreme",
+      "description": "\u03b1=1.0, \u03b2=0.0 (no voter channel) at m=k",
+      "paper_reference": "\u00a75.5.3 (Lemma 1 v0.6.1)",
+      "inputs": {
+        "alpha": 1.0,
+        "beta": 0.0,
+        "m": 5,
+        "k": 5
+      },
+      "expected": {
+        "alpha_eff": 1.0
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    }
+  ]
+}

--- a/prototypes/poua-sim/test_vectors/cost_to_attack.json
+++ b/prototypes/poua-sim/test_vectors/cost_to_attack.json
@@ -1,0 +1,80 @@
+{
+  "vectors": [
+    {
+      "name": "pure-pos-rho-0.2",
+      "description": "\u03ba=1 (all honest at r_min), target \u03c1=0.2",
+      "paper_reference": "\u00a75.3",
+      "inputs": {
+        "n_honest": 10,
+        "stake_per_honest": 100.0,
+        "reputation_per_honest": 1.0,
+        "target_rho": 0.2,
+        "r_min": 1.0
+      },
+      "expected": {
+        "attack_stake": 250.0,
+        "rho_realized": 0.2
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "kappa-8-rho-0.2",
+      "description": "honest at r_max=8, target \u03c1=0.2",
+      "paper_reference": "\u00a75.3",
+      "inputs": {
+        "n_honest": 10,
+        "stake_per_honest": 100.0,
+        "reputation_per_honest": 8.0,
+        "target_rho": 0.2,
+        "r_min": 1.0
+      },
+      "expected": {
+        "attack_stake": 2000.0,
+        "rho_realized": 0.2
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "kappa-8-byzantine-threshold",
+      "description": "honest at r_max=8, target \u03c1=1/3 (BFT cap)",
+      "paper_reference": "\u00a75.3",
+      "inputs": {
+        "n_honest": 10,
+        "stake_per_honest": 100.0,
+        "reputation_per_honest": 8.0,
+        "target_rho": 0.3333333333333333,
+        "r_min": 1.0
+      },
+      "expected": {
+        "attack_stake": 3999.9999999999995,
+        "rho_realized": 0.3333333333333333
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "kappa-4-rho-0.1",
+      "description": "honest at r=4, target \u03c1=0.1",
+      "paper_reference": "\u00a75.3",
+      "inputs": {
+        "n_honest": 20,
+        "stake_per_honest": 50.0,
+        "reputation_per_honest": 4.0,
+        "target_rho": 0.1,
+        "r_min": 1.0
+      },
+      "expected": {
+        "attack_stake": 444.44444444444446,
+        "rho_realized": 0.1
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    }
+  ]
+}

--- a/prototypes/poua-sim/test_vectors/lemma1_cost_to_grind.json
+++ b/prototypes/poua-sim/test_vectors/lemma1_cost_to_grind.json
@@ -1,0 +1,129 @@
+{
+  "vectors": [
+    {
+      "name": "single-pure-burn-v0",
+      "description": "v0 params, single proposer, pure burn, full ramp",
+      "paper_reference": "\u00a75.5.3 Lemma 1 (v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 1,
+        "k": 10,
+        "tau_burn": 0.5,
+        "eta": 0.001,
+        "delta_r": 7.0,
+        "destination": "pure_burn",
+        "adversary_stake_share": 0.0,
+        "governance_recovery_rate": 0.0
+      },
+      "expected": {
+        "alpha_eff": 0.7,
+        "f_gross_per_member": 10000.0,
+        "f_net_per_member": 5000.0
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-pure-burn-finite-k",
+      "description": "v0 params, m=4 in k=12 (Byzantine cap finite)",
+      "paper_reference": "\u00a75.5.3 Lemma 1 (v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 4,
+        "k": 12,
+        "tau_burn": 0.5,
+        "eta": 0.001,
+        "delta_r": 7.0,
+        "destination": "pure_burn",
+        "adversary_stake_share": 0.0,
+        "governance_recovery_rate": 0.0
+      },
+      "expected": {
+        "alpha_eff": 0.7749999999999999,
+        "f_gross_per_member": 9032.258064516129,
+        "f_net_per_member": 4516.129032258064
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-pure-burn-mainnet-k",
+      "description": "v0 params, m=33 in k=99 (close to asymptotic)",
+      "paper_reference": "\u00a75.5.3 Lemma 1 (v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 33,
+        "k": 99,
+        "tau_burn": 0.5,
+        "eta": 0.001,
+        "delta_r": 7.0,
+        "destination": "pure_burn",
+        "adversary_stake_share": 0.0,
+        "governance_recovery_rate": 0.0
+      },
+      "expected": {
+        "alpha_eff": 0.7969696969696969,
+        "f_gross_per_member": 8783.269961977187,
+        "f_net_per_member": 4391.634980988593
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-treasury-10pct",
+      "description": "v0 params, m=4 k=12, treasury with 10% governance recovery",
+      "paper_reference": "\u00a75.5.3 Lemma 1 (v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 4,
+        "k": 12,
+        "tau_burn": 0.5,
+        "eta": 0.001,
+        "delta_r": 7.0,
+        "destination": "treasury",
+        "adversary_stake_share": 0.0,
+        "governance_recovery_rate": 0.1
+      },
+      "expected": {
+        "alpha_eff": 0.7749999999999999,
+        "f_gross_per_member": 9032.258064516129,
+        "f_net_per_member": 4064.516129032258
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "byzantine-redistribution-1third",
+      "description": "v0 params, m=4 k=12, redistribution; adversary stake share 1/3",
+      "paper_reference": "\u00a75.5.3 Lemma 1 (v0.6.1)",
+      "inputs": {
+        "alpha": 0.7,
+        "beta": 0.3,
+        "m": 4,
+        "k": 12,
+        "tau_burn": 0.5,
+        "eta": 0.001,
+        "delta_r": 7.0,
+        "destination": "redistribution",
+        "adversary_stake_share": 0.3333333333333333,
+        "governance_recovery_rate": 0.0
+      },
+      "expected": {
+        "alpha_eff": 0.7749999999999999,
+        "f_gross_per_member": 9032.258064516129,
+        "f_net_per_member": 3010.7526881720432
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    }
+  ]
+}

--- a/prototypes/poua-sim/test_vectors/reputation_update.json
+++ b/prototypes/poua-sim/test_vectors/reputation_update.json
@@ -1,0 +1,124 @@
+{
+  "vectors": [
+    {
+      "name": "zero-input-no-change",
+      "description": "g_v=0, b_v=0 leaves reputation unchanged",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 4.0,
+        "g_v": 0.0,
+        "b_v": 0.0,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 4.0
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "growth-saturated",
+      "description": "g_v=g_max yields \u03b7\u00b7g_max per epoch growth",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 1.0,
+        "g_v": 233.0,
+        "b_v": 0.0,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 1.233
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "clip-to-r_max",
+      "description": "huge g_v clips at r_max",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 7.5,
+        "g_v": 1000000.0,
+        "b_v": 0.0,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 8.0
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "clip-to-r_min",
+      "description": "huge slash clips at r_min",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 8.0,
+        "g_v": 0.0,
+        "b_v": 1000000.0,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 1.0
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "net-with-growth-and-slash",
+      "description": "growth \u03b7\u00b7g_max canceled by partial slash",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 4.0,
+        "g_v": 233.0,
+        "b_v": 0.233,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 3.9999999999999996
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    },
+    {
+      "name": "severe-slash-from-r_max",
+      "description": "severity = (r_max - r_min)/\u03bb + (\u03b7\u00b7g_max)/\u03bb takes r_max \u2192 r_min under full participation",
+      "paper_reference": "\u00a74.3",
+      "inputs": {
+        "reputation": 8.0,
+        "g_v": 233.0,
+        "b_v": 7.233,
+        "eta": 0.001,
+        "lambda": 1.0,
+        "r_min": 1.0,
+        "r_max": 8.0
+      },
+      "expected": {
+        "reputation_next": 1.0000000000000009
+      },
+      "tolerance": {
+        "absolute": 1e-09
+      }
+    }
+  ]
+}

--- a/prototypes/poua-sim/tests/test_test_vectors.py
+++ b/prototypes/poua-sim/tests/test_test_vectors.py
@@ -1,0 +1,163 @@
+"""Cross-language test vector consumer.
+
+Each vector under ``test_vectors/`` is one ``(inputs, expected)`` pair
+derived from the simulator's analytical functions. This test re-runs the
+simulator's implementation against the vector inputs and asserts the
+output matches expected within the vector's stated tolerance.
+
+A future Rust consumer in ``ligate-chain`` parses the same JSON and runs
+the same checks against the production implementation. Drift between
+paper, simulator, and chain becomes a CI failure in whichever repo lags.
+
+If a paper claim changes, the workflow is:
+
+1. Update the relevant analytical function in ``poua_sim``.
+2. Re-run ``scripts/generate_test_vectors.py``.
+3. ``ligate-chain`` re-runs its consumer; failures point at the changed claim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from poua_sim import (
+    BurnDestination,
+    Layer3Config,
+    ReputationParams,
+    Validator,
+    alpha_eff,
+    analytical_attack_stake,
+    apply_reputation_update,
+    layer3_net_burn,
+)
+
+VECTORS_DIR = Path(__file__).resolve().parent.parent / "test_vectors"
+
+
+def _within_tolerance(actual: float, expected: float, tolerance: dict) -> bool:
+    """Return True iff ``actual`` matches ``expected`` within stated tolerance."""
+    abs_tol = tolerance.get("absolute")
+    rel_tol = tolerance.get("relative")
+    if abs_tol is None and rel_tol is None:
+        raise ValueError("vector must specify at least one of {absolute, relative} tolerance")
+    diff = abs(actual - expected)
+    if abs_tol is not None and diff <= abs_tol:
+        return True
+    if rel_tol is not None and expected != 0 and diff / abs(expected) <= rel_tol:
+        return True
+    return False
+
+
+def _load(filename: str) -> list[dict]:
+    """Load and return the vectors list from a JSON file under ``test_vectors/``."""
+    path = VECTORS_DIR / filename
+    if not path.exists():
+        pytest.skip(f"vector file {filename} not found; run scripts/generate_test_vectors.py")
+    return json.loads(path.read_text())["vectors"]
+
+
+# --- §4.3 reputation update -----------------------------------------
+
+
+@pytest.mark.parametrize("vector", _load("reputation_update.json"), ids=lambda v: v["name"])
+def test_reputation_update_vector(vector):
+    inp = vector["inputs"]
+    params = ReputationParams(
+        eta=inp["eta"],
+        lambda_=inp["lambda"],
+        r_min=inp["r_min"],
+        r_max=inp["r_max"],
+        # Other fields default to v0; not exercised by this vector.
+    )
+    v = Validator(address="v0", stake=100.0, reputation=inp["reputation"])
+    actual = apply_reputation_update(v, params, g_v=inp["g_v"], b_v=inp["b_v"])
+    expected = vector["expected"]["reputation_next"]
+    assert _within_tolerance(actual, expected, vector["tolerance"]), (
+        f"reputation_update[{vector['name']}]: actual={actual}, expected={expected}"
+    )
+
+
+# --- §5.5.3 α_eff --------------------------------------------------
+
+
+@pytest.mark.parametrize("vector", _load("alpha_eff.json"), ids=lambda v: v["name"])
+def test_alpha_eff_vector(vector):
+    inp = vector["inputs"]
+    actual = alpha_eff(alpha=inp["alpha"], beta=inp["beta"], m=inp["m"], k=inp["k"])
+    expected = vector["expected"]["alpha_eff"]
+    assert _within_tolerance(actual, expected, vector["tolerance"]), (
+        f"alpha_eff[{vector['name']}]: actual={actual}, expected={expected}"
+    )
+
+
+# --- §5.3 cost-to-attack -------------------------------------------
+
+
+@pytest.mark.parametrize("vector", _load("cost_to_attack.json"), ids=lambda v: v["name"])
+def test_cost_to_attack_vector(vector):
+    inp = vector["inputs"]
+    honest = [
+        Validator(
+            address=f"v{i}",
+            stake=inp["stake_per_honest"],
+            reputation=inp["reputation_per_honest"],
+        )
+        for i in range(inp["n_honest"])
+    ]
+    s_c = analytical_attack_stake(
+        target_rho=inp["target_rho"],
+        honest_validators=honest,
+        r_min=inp["r_min"],
+    )
+    expected = vector["expected"]
+    tol = vector["tolerance"]
+    assert _within_tolerance(s_c, expected["attack_stake"], tol), (
+        f"cost_to_attack[{vector['name']}] attack_stake: actual={s_c}, expected={expected['attack_stake']}"
+    )
+    # Also check realized weight share once the adversary at r_min injects with stake s_c.
+    adversary_weight = s_c * inp["r_min"]
+    honest_weight = sum(v.weight for v in honest)
+    rho_realized = adversary_weight / (adversary_weight + honest_weight)
+    assert _within_tolerance(rho_realized, expected["rho_realized"], tol), (
+        f"cost_to_attack[{vector['name']}] rho_realized: actual={rho_realized}, expected={expected['rho_realized']}"
+    )
+
+
+# --- §5.5.3 Lemma 1 cost-to-grind ----------------------------------
+
+
+@pytest.mark.parametrize("vector", _load("lemma1_cost_to_grind.json"), ids=lambda v: v["name"])
+def test_lemma1_vector(vector):
+    inp = vector["inputs"]
+    expected = vector["expected"]
+    tol = vector["tolerance"]
+
+    # α_eff
+    a_eff = alpha_eff(alpha=inp["alpha"], beta=inp["beta"], m=inp["m"], k=inp["k"])
+    assert _within_tolerance(a_eff, expected["alpha_eff"], tol), (
+        f"lemma1[{vector['name']}] alpha_eff: actual={a_eff}, expected={expected['alpha_eff']}"
+    )
+
+    # F_gross per member
+    gross_per_member = inp["delta_r"] / (inp["eta"] * a_eff)
+    assert _within_tolerance(gross_per_member, expected["f_gross_per_member"], tol), (
+        f"lemma1[{vector['name']}] f_gross_per_member: actual={gross_per_member}, expected={expected['f_gross_per_member']}"
+    )
+
+    # F_net per member
+    config = Layer3Config(
+        tau_burn=inp["tau_burn"],
+        destination=BurnDestination(inp["destination"]),
+        governance_recovery_rate=inp["governance_recovery_rate"],
+    )
+    f_net = layer3_net_burn(
+        gross_fees=gross_per_member,
+        config=config,
+        adversary_stake_share=inp["adversary_stake_share"],
+    )
+    assert _within_tolerance(f_net, expected["f_net_per_member"], tol), (
+        f"lemma1[{vector['name']}] f_net_per_member: actual={f_net}, expected={expected['f_net_per_member']}"
+    )


### PR DESCRIPTION
## What

Cross-language test vectors for the four mechanism algebras the paper relies on:

- **§4.3 reputation update** — `r_v(t+E) = clip(r_v + η·g_v - λ·b_v)`
- **§5.5.3 α_eff** — cartel-aware effective proposer share
- **§5.3 cost-to-attack** — capital adversary stake inversion
- **§5.5.3 Lemma 1 cost-to-grind** — F_net per cartel member, per burn destination

Each vector is a JSON `(inputs, expected, tolerance)` triple. The Python
harness in `tests/test_test_vectors.py` re-runs the simulator's implementation
against each vector and asserts the output matches expected. A future Rust
consumer in `ligate-chain` parses the same JSON and runs the same checks
against the production implementation.

This is the structural fix from [#23](https://github.com/ligate-io/ligate-research/issues/23):
claim-vs-implementation drift becomes impossible without a CI failure in
whichever repo lags.

## Why

The v0.6 → v0.6.1 patch closed an inconsistency between the Lemma 1 proof
and §4.3 of the same paper. The simulator caught it because its tests
implement §4.3 literally; the proof's extra "proposer also votes on its
own block" credit fell out as an empirical mismatch during M2-M4.

Without test vectors, every numerical claim in the paper relies on the
author hand-computing it correctly and the implementation following suit.
With test vectors, the algebra is encoded once in the simulator's
analytical functions, exported as JSON, and consumed by every implementation.

## What landed

### `test_vectors/` directory

```
test_vectors/
├── README.md                   # format spec + workflow doc
├── reputation_update.json      # 6 vectors, §4.3
├── alpha_eff.json              # 7 vectors, §5.5.3
├── cost_to_attack.json         # 4 vectors, §5.3
└── lemma1_cost_to_grind.json   # 5 vectors, §5.5.3
```

22 vectors total, covering edge cases (clipping, single-proposer, full-cartel,
each burn destination, finite-k vs asymptotic, etc.).

### `scripts/generate_test_vectors.py`

The vectors are produced by calling the simulator's analytical functions
(`apply_reputation_update`, `alpha_eff`, `analytical_attack_stake`,
`layer3_net_burn`) with hand-curated inputs and writing the outputs. This
is the single source of truth: change the analytical function, regenerate
vectors, every consumer (Python here, future Rust) gets a clean test
failure that points at the changed claim.

### `tests/test_test_vectors.py`

22 parametrized tests — one per vector — that load the JSON, re-run the
analytical function on the simulator's implementation, and assert the
output matches within stated tolerance.

```
============================== 135 passed in 4.67s ==============================
```

(113 prior tests + 22 new vector tests; full suite still passes.)

## Workflow when paper claims change

1. Update the relevant analytical function in `poua_sim` (e.g., a corrected
   `alpha_eff` formula).
2. Re-run `python scripts/generate_test_vectors.py`.
3. The Python harness re-validates against the new vectors.
4. The Rust consumer in `ligate-chain` re-runs and either matches (drift
   absorbed) or fails-fast (drift surfaced).

The vectors are intentionally language-agnostic: only floats, ints, strings,
and lists. No Python pickle, no Rust serde-specific tags.

## What this closes

- Structural component of [#23](https://github.com/ligate-io/ligate-research/issues/23)
  — drift between paper algebra, simulator, and chain implementation now
  fails-fast in CI.
- Future v0.7 paper sweep can rely on this discipline: every numerical
  claim in the paper either has a test vector or doesn't ship.

## What this does NOT close

- The CI plumbing on the `ligate-chain` side. That's done when `ligate-chain`
  adds its consumer (separate PR over there).
- The "every paper claim links to a sim test" inline-citation rule from #23.
  That's a v0.7 paper-edit pass, not infra.
