### PR TITLE
Per-Schema Fee Markets: v0.1 outline scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository is the upstream of the technical claims our marketing surface (l
 | Paper | Status | Latest version | Topic |
 |---|---|---|---|
 | [Proof of Useful Attestation (PoUA)](papers/poua/) | Working draft | v0.7.1 (2026-05-02) | Consensus weighting primitive that aligns validator influence with the production of valid attestation work |
+| [Per-Schema Fee Markets](papers/per-schema-fees/) | Outline | v0.1 (2026-05-02) | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
 
 Future papers planned (filed as issues in this repo):
 

--- a/papers/README.md
+++ b/papers/README.md
@@ -6,7 +6,8 @@ Working papers on Ligate's protocol-level research direction.
 
 | Paper | Latest | Status | Topic |
 |---|---|---|---|
-| [PoUA — Proof of Useful Attestation](poua/) | v0.7 (2026-05-02) | Draft, internal review | Consensus weighting primitive aligning validator influence with valid attestation work |
+| [PoUA — Proof of Useful Attestation](poua/) | v0.7.1 (2026-05-02) | Draft, internal review | Consensus weighting primitive aligning validator influence with valid attestation work |
+| [Per-Schema Fee Markets](per-schema-fees/) | v0.1 (2026-05-02) | Outline | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
 
 PoUA v0.7 is the empirical-validation milestone: every load-bearing claim has a published figure produced by the [reference simulator](../prototypes/poua-sim/), and cross-language test vectors at [`prototypes/poua-sim/test_vectors/`](../prototypes/poua-sim/test_vectors/) encode the analytical truths so the production implementation can re-validate the algebra in lockstep.
 
@@ -16,7 +17,6 @@ Filed as GitHub issues in this repo. Each will land here as a working draft when
 
 | Paper | Issue | Topic |
 |---|---|---|
-| Per-schema fee markets | [#4](https://github.com/ligate-io/ligate-research/issues/4) | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
 | Native delegation | [#5](https://github.com/ligate-io/ligate-research/issues/5) | Hot-key / master-key separation as a runtime primitive; foundation for Iris MCP relayer |
 | Cross-schema composition | [#6](https://github.com/ligate-io/ligate-research/issues/6) | Typed attestation references with slashing-aware proof propagation |
 | Time-locked / commit-reveal attestations | [#7](https://github.com/ligate-io/ligate-research/issues/7) | Sealed-bid auctions, embargoed press, regulatory time-locks |

--- a/papers/per-schema-fees/README.md
+++ b/papers/per-schema-fees/README.md
@@ -1,0 +1,52 @@
+# Per-Schema Fee Markets
+
+Per-schema EIP-1559-style fee dynamics for attestation-native chains.
+
+## Latest
+
+- **Working paper**: [`per-schema-fees.md`](per-schema-fees.md) (markdown source) — PDF to be generated when v0.2 has substantive content
+- **Version**: v0.1
+- **Status**: **Outline.** Section headings with intent annotations; no formal content yet. Authoring begins when [#4](https://github.com/ligate-io/ligate-research/issues/4) gets pulled into a focused work cycle.
+- **Date**: 2026-05-02
+
+## Abstract (placeholder)
+
+A unified fee market across all transactions assumes homogeneous demand. Attestation chains break that assumption: a high-throughput schema (e.g., AI-provenance receipts at millions per day) and a low-throughput high-value schema (e.g., sovereign-identity proofs at hundreds per day) have fundamentally different demand profiles. This paper proposes per-schema fee markets with EIP-1559-style base-fee adjustment, where each registered schema carries its own target utilization, base fee, and tip mechanism. The mechanism is composable with sponsored-gas patterns (Iris MCP relayer paying fees on behalf of autonomous agents) and integrates cleanly with PoUA reputation: validators earn reputation through processing valid attestations across schemas, fee preference does not collapse the moat.
+
+## What's planned for v0.2
+
+The v0.2 milestone is the first substantive draft. Target deliverables:
+
+- Full §1 Introduction with thesis, problem statement, central question, contributions, structure
+- §3 System Model formalising the schema as fee-market unit, validator income decomposition (per-schema base fee + tip + protocol block reward), demand profile types
+- §4 Mechanism specification: base-fee adjustment formula, target utilization, max change per epoch, integration with PoUA proposer selection
+- §5 Security Analysis: cross-schema arbitrage, fee-griefing attacks, base-fee manipulation by colluding validators
+- §6 Incentive Analysis under three roles (validator, builder, sponsor)
+- §A simulator scaffolding under `prototypes/per-schema-fees-sim/`
+
+## Discipline
+
+This paper adopts the v0.7-PoUA discipline from draft v0.1:
+
+- Every numerical claim links to a simulator test or test vector (validated by `scripts/check_citations.py`)
+- Cross-language test vectors when relevant
+- Empirical figures referenced from `prototypes/per-schema-fees-sim/out/` (when the simulator exists)
+
+See [`papers/poua/`](../poua/) for the worked example of this discipline applied through a v0.1 → v0.7 cycle.
+
+## Open questions
+
+- Single base-fee adjustment vs. multi-resource fee markets (gas + storage + validator-attention as separate axes)
+- Interaction with the §4.4.2 adaptive $\tau_{\text{burn}}$ rebase: schema-fee drift is a primary input to the rebase trigger
+- Sponsored-gas relayer model: who eats the variance in base fees when the sponsor pre-commits to a schema's fee curve
+- Cross-schema censorship: a validator preferring high-fee schemas could violate §A.1's KL-divergence detector (paper-wide schema distribution); the detector calibration may need to incorporate this paper's fee-aware mempool model
+
+## Authoring
+
+Filed as [issue #4](https://github.com/ligate-io/ligate-research/issues/4). Pull into a focused work cycle when:
+
+- The PoUA paper is at v0.8+ (post-external-review feedback integrated)
+- Devnet has at least one schema with non-trivial attestation volume so calibration draws on real numbers
+- Contributor or external collaborator with fee-market expertise is engaged
+
+In the meantime, this scaffold reserves the directory and lays out the v0.2 structure. New ideas that belong in this paper land as comments on #4.

--- a/papers/per-schema-fees/per-schema-fees.md
+++ b/papers/per-schema-fees/per-schema-fees.md
@@ -1,0 +1,211 @@
+---
+title: "Per-Schema Fee Markets for Attestation-Native Chains"
+author: "Ligate Labs"
+date: "2026-05-02"
+---
+
+## Per-Schema Fee Markets for Attestation-Native Chains
+
+**Ligate Labs Research, Working Paper v0.1 (outline)**
+
+**Date:** 2026-05-02
+
+**Status:** **Outline only.** Section headings with intent annotations; no formal content yet. Authoring begins when [#4](https://github.com/ligate-io/ligate-research/issues/4) gets pulled into a focused work cycle. See [`README.md`](README.md) for the v0.2 milestone scope.
+
+**Contact:** hello@ligate.io
+
+**Version history:** v0.1 (outline scaffold).
+
+\newpage
+
+## Abstract
+
+A unified fee market across all transactions assumes homogeneous demand. Attestation-native chains break that assumption: a high-throughput schema (AI-provenance receipts at millions of attestations per day) and a low-throughput high-value schema (sovereign-identity proofs at hundreds per day) have fundamentally different demand profiles, fee elasticities, and inclusion preferences. This paper proposes per-schema fee markets with EIP-1559-style base-fee adjustment, where each registered schema carries its own target utilization, base fee, tip mechanism, and adjustment-rate parameter. The mechanism is composable with sponsored-gas patterns (Iris MCP relayer paying fees on behalf of autonomous agents) and integrates with PoUA reputation: validators earn reputation through processing valid attestations across schemas, so per-schema fee preference must be checked against §A.1 censorship detection (handled in §5 of this paper).
+
+[**v0.2 will fill in:** the formal proposition, the mechanism's central inequality, the cross-schema-arbitrage cost-to-attack relationship, the calibration recommendation, and the limitations.]
+
+---
+
+## 1. Introduction
+
+### 1.1 The Heterogeneous-Demand Thesis
+
+[**v0.2:** Why a single fee market is the wrong abstraction for attestation-native chains. The schema is the natural unit; demand profiles vary by orders of magnitude. Cite Themisra (high-throughput, low-fee) vs. sovereign-identity examples (low-throughput, high-fee).]
+
+### 1.2 Why Now
+
+[**v0.2:** EIP-1559 has shipped on Ethereum mainnet since 2021; multi-resource fee markets are an active research area; PoUA's per-schema accounting at the consensus layer makes per-schema fee dynamics first-class. The convergence is now.]
+
+### 1.3 The Misalignment Problem
+
+[**v0.2:** A unified base fee adjusts to network-wide congestion. A high-throughput schema with stable demand sees its fee swing because of unrelated activity in another schema. Conversely, a low-throughput schema spike doesn't get the dedicated price discovery it needs.]
+
+### 1.4 The Central Question
+
+> [**v0.2:** How can a chain price attestation work in a way that respects per-schema demand heterogeneity, without re-introducing the cross-schema-arbitrage attack surface?]
+
+### 1.5 Approach in Brief
+
+[**v0.2:** Three-sentence preview. Per-schema base fee with EIP-1559 adjustment formula. Validator-side reputation tracks valid work across all schemas (PoUA inheritance) so per-fee preference is bounded by §A.1 detection. Cross-schema fee-griefing handled by §5.]
+
+### 1.6 Contributions
+
+[**v0.2:** Mechanism specification, integration with PoUA, security analysis, comparison with EIP-1559 + Cosmos fee markets + Solana priority fees.]
+
+### 1.6.1 Status of Claims
+
+[**v0.2:** Same panel as PoUA v0.7 §1.6.1: proven, bounded-under-stated-assumptions, empirical/heuristic.]
+
+### 1.7 Scope and Non-Goals
+
+[**v0.2:** In scope: per-schema fee dynamics, EIP-1559 adjustment, integration with PoUA reputation. Out of scope: multi-resource fee markets (separate paper), MEV (separate concern), cross-chain fee-market portability.]
+
+### 1.8 Document Structure
+
+[**v0.2:** TOC walkthrough.]
+
+---
+
+## 2. Background and Related Work
+
+### 2.1 EIP-1559
+
+[**v0.2:** Ethereum's base-fee mechanism, target utilization, max-change-per-block.]
+
+### 2.2 Multi-Resource Fee Markets
+
+[**v0.2:** Solana's priority fees, Cosmos's fee market module, Aptos's gas pricing.]
+
+### 2.3 Attestation Chains and Schema Heterogeneity
+
+[**v0.2:** EAS, Ceramic, restaking-AVS fee dynamics, Ligate's schema-as-economic-unit position.]
+
+---
+
+## 3. System Model
+
+### 3.1 The Schema as Fee-Market Unit
+
+[**v0.2:** Formal definition. Each registered schema $\sigma$ carries a fee-market state $(b_\sigma, u_\sigma, T_\sigma)$: base fee, current utilization, target utilization.]
+
+### 3.2 Validator Income Decomposition
+
+[**v0.2:** Block reward $R_b$ + per-schema fee tip $T_\sigma$ + base fee burn $B_\sigma$. Validators receive tips, burn base fees (analogous to EIP-1559 burn).]
+
+### 3.3 Demand Profile Taxonomy
+
+[**v0.2:** Three regimes — high-volume / low-fee, low-volume / high-fee, bursty / spiky — with worked examples.]
+
+---
+
+## 4. Per-Schema Fee Mechanism
+
+### 4.1 Base-Fee Adjustment Formula
+
+[**v0.2:** Per-schema EIP-1559 adjustment:
+
+$$b_\sigma(t+1) = b_\sigma(t) \cdot (1 + \xi \cdot (u_\sigma(t) - T_\sigma) / T_\sigma)$$
+
+clipped to $[b_\sigma^{\min}, b_\sigma^{\max}]$. Recommended $\xi = 1/8$ (matches EIP-1559's max change per block).]
+
+### 4.2 Target Utilization Calibration
+
+[**v0.2:** Per-schema target. Recommended $T_\sigma = 0.5$ default; schemas with bursty demand may want lower target (more headroom).]
+
+### 4.3 Tip Mechanism
+
+[**v0.2:** Tip-as-priority within a schema's allocation. Tips go to the proposing validator (analogous to EIP-1559 priority fee).]
+
+### 4.4 Base-Fee Burn
+
+[**v0.2:** Burn fraction of base fee per attestation. Connection to PoUA's $\tau_{\text{burn}}$ (the §5.5.3 mechanism is computed against this paper's per-schema base fee, not a global value).]
+
+### 4.5 Integration with PoUA
+
+[**v0.2:** How the validator's per-schema fee preference interacts with PoUA reputation. Per-schema fee revenue feeds into the validator's $R_f$ in PoUA §6.3. Reputation is schema-agnostic: validator processes valid attestations across schemas, all count toward $g_v$.]
+
+---
+
+## 5. Security Analysis
+
+### 5.1 Cross-Schema Arbitrage
+
+[**v0.2:** Adversary registers a high-fee schema, induces the chain to allocate it disproportionate proposer attention. Defended by PoUA's §A.1 KL-divergence censorship detector and by per-schema target utilization.]
+
+### 5.2 Base-Fee Manipulation by Validator Coalition
+
+[**v0.2:** Coalition selectively includes / excludes attestations from a schema to manipulate its base fee. Bounded by schema-level demand (price discovery happens in mempool regardless of inclusion choice) and §A.1 detection.]
+
+### 5.3 Fee-Griefing Across Schemas
+
+[**v0.2:** Adversary submits high-tip attestations to a target schema to inflate its base fee, causing legitimate users to pay more. Bounded by the EIP-1559 max-change-per-epoch parameter.]
+
+### 5.4 Sponsored-Gas Adversarial Patterns
+
+[**v0.2:** Iris-style sponsored gas: Iris pays for an autonomous agent's attestation. Adversary patterns: agent submits floods of attestations, exhausting Iris's budget; Iris pre-commits to a fee curve, adversary causes that curve to exceed real base fee. Mitigations.]
+
+---
+
+## 6. Incentive Analysis
+
+### 6.1 Validator-Side
+
+[**v0.2:** Per-schema fee revenue diversification. Reputation accumulation is schema-agnostic, so validators are not punished for inclusion preferences (within §A.1 bounds).]
+
+### 6.2 Builder-Side (Block Builders, MEV)
+
+[**v0.2:** Cross-schema bundling, ordering preferences, MEV implications. Defer detailed treatment to a separate paper if needed.]
+
+### 6.3 Sponsor-Side (Iris and Other Relayers)
+
+[**v0.2:** Sponsored-gas economics. Pre-committed fee curves, retroactive reimbursement, pricing-cap models.]
+
+---
+
+## 7. Implementation in Ligate Chain
+
+### 7.1 Sovereign SDK Integration Points
+
+[**v0.2:** Per-schema state extension: new `FeeMarketState` field on schemas. Updated runtime hook for base-fee adjustment at epoch boundaries.]
+
+### 7.2 Recommended v0 Parameters
+
+[**v0.2:** Per-schema $T_\sigma$, $\xi$, $b_\sigma^{\min}$, $b_\sigma^{\max}$ defaults.]
+
+### 7.3 Migration from Unified Fee Market
+
+[**v0.2:** Bootstrap-period unified fee market; activation of per-schema markets via governance after warmup.]
+
+---
+
+## 8. Comparison with Prior Systems
+
+[**v0.2:** Table comparing this paper, Ethereum EIP-1559, Solana priority fees, Cosmos fee module, Aptos gas pricing across axes: per-resource granularity, target utilization mechanism, burn fraction, sponsor-friendly extensions.]
+
+---
+
+## 9. Limitations and Future Work
+
+### 9.1 Limitations
+
+[**v0.2:** Empirical validation pending devnet operation; sponsored-gas adversary model is heuristic; multi-resource fee market separation deferred.]
+
+### 9.2 Future Work
+
+[**v0.2:** Multi-resource fee markets, dynamic schema target adjustment, on-chain fee-market parameter governance.]
+
+---
+
+## 10. Conclusion
+
+[**v0.2:** Per-schema fee markets are the natural unit for attestation-native chains. The mechanism integrates with PoUA reputation cleanly. Combined with the §4.4.2 adaptive $\tau_{\text{burn}}$ rebase, the chain has both per-schema demand-side price discovery and protocol-level drift response.]
+
+---
+
+## 11. Frequently Asked Questions
+
+[**v0.2:** Q1. Why per-schema and not multi-resource? Q2. How does this interact with EIP-1559 if Ligate later bridges to Ethereum? Q3. What if a schema has near-zero traffic? Q4. Doesn't this just reintroduce the unified-fee-market problems at the schema level? Etc.]
+
+---
+
+*End of working paper v0.1 (outline). Substantive authoring begins with v0.2; see [`README.md`](README.md) and [issue #4](https://github.com/ligate-io/ligate-research/issues/4).*


### PR DESCRIPTION
## What

Reserves `papers/per-schema-fees/` and lays down a v0.1 outline for the next paper in the queue: per-schema EIP-1559-style fee markets for attestation-native chains.

This is a **scaffold**, not substantive content. Every section is a heading with a one-line intent annotation marked `[**v0.2:** ...]`. v0.2 is the first substantive draft milestone.

Paper context: [issue #4](https://github.com/ligate-io/ligate-research/issues/4).

## What landed

- `papers/per-schema-fees/README.md` — paper-page entry point with abstract placeholder, v0.2 milestone scope, discipline statement, open questions, authoring conditions
- `papers/per-schema-fees/per-schema-fees.md` — outline with 11 sections (1 Introduction through 11 FAQ), each populated with section heading + intent annotation
- `papers/README.md` — listing updated: per-schema fees moved from "Planned" to "Active (Outline)"
- `README.md` — top-level papers table includes the new entry

## Why scaffold now

Three reasons:

1. **Naming and structure.** Future contributors who pick this up have a directory to commit to and an outline to populate, rather than starting from the template. Reduces decision-paralysis at the start of authoring.
2. **Discipline propagation.** The outline references the v0.7-PoUA discipline (claim citations, simulator-driven figures, test vectors) so the next paper inherits it from draft v0.1.
3. **Roadmap visibility.** `papers/README.md` now shows the lab is actively scaffolding the next paper, not just sitting on PoUA.

## Authoring trigger

The `README.md` lists three conditions for pulling this into a focused work cycle:

1. PoUA at v0.8+ (post-external-review feedback integrated)
2. Devnet has at least one schema with non-trivial attestation volume
3. Contributor or external collaborator with fee-market expertise engaged

Until then, ideas land as comments on #4.

## Open questions surfaced in the outline

- Single base-fee adjustment vs. multi-resource fee markets (gas + storage + validator-attention)
- Interaction with PoUA §4.4.2 adaptive $\\tau_{\\text{burn}}$ rebase (schema-fee drift is a primary input to the rebase trigger)
- Sponsored-gas relayer model: Iris MCP relayer pre-commits to fee curve, who absorbs base-fee variance
- Cross-schema censorship: a validator preferring high-fee schemas may violate §A.1 KL-divergence detector calibration

## Acceptance

- [x] Directory `papers/per-schema-fees/` reserved
- [x] README with v0.2 scope + authoring trigger conditions
- [x] Section-headings outline with intent annotations
- [x] Listed in `papers/README.md` and root `README.md`
- [x] No new prototype simulator code yet (scaffolds when v0.2 authoring begins)