### PR TITLE
Per-Schema Fees v0.1.1: substantive §4 mechanism (EIP-1559 + PoUA integration)

### DIFF
--- a/papers/per-schema-fees/README.md
+++ b/papers/per-schema-fees/README.md
@@ -4,10 +4,10 @@ Per-schema EIP-1559-style fee dynamics for attestation-native chains.
 
 ## Latest
 
-- **Working paper**: [`per-schema-fees.md`](per-schema-fees.md) (markdown source) — PDF to be generated when v0.2 has substantive content
-- **Version**: v0.1
-- **Status**: **Outline.** Section headings with intent annotations; no formal content yet. Authoring begins when [#4](https://github.com/ligate-io/ligate-research/issues/4) gets pulled into a focused work cycle.
-- **Date**: 2026-05-02
+- **Working paper**: [`per-schema-fees.md`](per-schema-fees.md) (markdown source) — PDF to be generated when v0.2 substantive content lands across §3 + §4 + §5 + §6
+- **Version**: v0.1.1
+- **Status**: **Outline + mechanism section substantive.** §4 (per-schema fee mechanism) is now substantive prose with formal definitions, integration with PoUA τ_burn rebase, and sponsored-gas (paymaster) accounting. §1, §2, §3, §5+ remain v0.1 outline.
+- **Date**: 2026-05-04 (updated; original v0.1 scaffold 2026-05-02)
 
 ## Abstract (placeholder)
 

--- a/papers/per-schema-fees/per-schema-fees.md
+++ b/papers/per-schema-fees/per-schema-fees.md
@@ -100,29 +100,99 @@ A unified fee market across all transactions assumes homogeneous demand. Attesta
 
 ## 4. Per-Schema Fee Mechanism
 
+This section specifies the per-schema fee market: how the base fee adjusts in response to schema-specific demand, how priority within a schema is auctioned via tips, how base-fee revenue is split between burn and validator reward, and how the mechanism integrates with PoUA reputation accounting.
+
+The mechanism is a per-schema instantiation of EIP-1559's adjustment dynamics, with three modifications appropriate to attestation-native chains: (1) per-schema state rather than global state, (2) integration with PoUA's adaptive $\tau_{\text{burn}}$ rebase from PoUA §4.4.2, and (3) explicit accounting for sponsored-gas relayers (used by the Iris MCP relayer, design-partner-validated).
+
 ### 4.1 Base-Fee Adjustment Formula
 
-[**v0.2:** Per-schema EIP-1559 adjustment:
+For each registered schema $\sigma \in \Sigma$, the chain maintains a per-schema base fee $b_\sigma(t)$, target utilization $T_\sigma$, and observed utilization $u_\sigma(t)$. Per-block adjustment follows the EIP-1559 form:
 
-$$b_\sigma(t+1) = b_\sigma(t) \cdot (1 + \xi \cdot (u_\sigma(t) - T_\sigma) / T_\sigma)$$
+$$b_\sigma(t+1) = b_\sigma(t) \cdot \left(1 + \xi \cdot \frac{u_\sigma(t) - T_\sigma}{T_\sigma}\right)$$
 
-clipped to $[b_\sigma^{\min}, b_\sigma^{\max}]$. Recommended $\xi = 1/8$ (matches EIP-1559's max change per block).]
+clipped to $[b_\sigma^{\min}, b_\sigma^{\max}]$, where:
+
+- $u_\sigma(t) \in [0, 1]$ is the fraction of schema $\sigma$'s allocated attestation slots filled in block $t$
+- $T_\sigma \in (0, 1)$ is the schema's target utilization (§4.2)
+- $\xi$ is the per-block max-change parameter
+- $[b_\sigma^{\min}, b_\sigma^{\max}]$ are governance-tunable clip bounds
+
+**Recommended $\xi$.** $\xi = 1/8$ matches EIP-1559's calibration (max $\pm 12.5\%$ per block). At the v0 block time of 12 seconds, this gives a $\sim 64\%$ swing potential per epoch (6 blocks of $1.125$); aggressive enough to track demand shifts, gentle enough to avoid oscillation.
+
+**Allocated slots per schema.** A block's total attestation capacity is partitioned across schemas at proposer-selection time. The simplest allocation is fixed-share-per-schema (each schema gets $\lfloor C_{\text{block}} \cdot w_\sigma \rfloor$ slots, $\sum w_\sigma = 1$); a richer allocation is governance-tunable per-schema utilization-aware. v0 ships fixed-share as the default.
+
+**Convergence and stability.** The dynamics admit a fixed point at $u_\sigma^* = T_\sigma$. Around this fixed point, perturbations decay geometrically with rate $1 - \xi$ at first order. The mechanism inherits EIP-1559's convergence behavior; per-schema isolation means a high-utilization schema cannot drag down the base fee of a low-utilization schema. This is the central architectural advantage of the per-schema design.
+
+**Drift interaction with PoUA $\tau_{\text{burn}}$ rebase.** Both this paper's per-schema base fee and PoUA §4.4.2's $\tau_{\text{burn}}$ are time-varying parameters. The composition is hierarchical: $\tau_{\text{burn}}$ governs what fraction of $b_\sigma$ is burned (§4.4); $b_\sigma$ itself adjusts per-schema. The v0.8 PoUA paper §4.4.3 spec at [`papers/poua/specs/eta-lambda-rebase.md`](../poua/specs/eta-lambda-rebase.md) §5.2 verifies that the two rebases are first-order independent — schema-fee drift is the input to $b_\sigma$, while cost-to-grind drift is the input to $\tau_{\text{burn}}$.
 
 ### 4.2 Target Utilization Calibration
 
-[**v0.2:** Per-schema target. Recommended $T_\sigma = 0.5$ default; schemas with bursty demand may want lower target (more headroom).]
+The target utilization $T_\sigma$ controls the trade-off between **predictability** (low $T_\sigma$, more headroom for spikes) and **revenue extraction** (high $T_\sigma$, prices closer to demand peak).
+
+**Recommended default: $T_\sigma = 0.5$.** Matches EIP-1559's choice. Provides $2\times$ headroom over steady-state demand.
+
+**Schema-specific deviations.**
+
+| Schema profile | Recommended $T_\sigma$ | Rationale |
+|---|---|---|
+| Stable, low-volume (e.g., regulatory filings) | 0.7 | Variance is low; can pack closer to demand peak without congestion |
+| High-volume, low-variance (e.g., Themisra prompts) | 0.5 | Default; balances predictability and revenue |
+| Bursty (e.g., Kleidon mint events around drops) | 0.3 | Heavy headroom to absorb spikes without triggering rapid base-fee climbs |
+| Real-time / time-critical (e.g., Iris agent actions) | 0.3 | Latency sensitivity demands immediate-inclusion guarantees during normal load |
+
+[**Measured at v0.2.5+:** these are architectural defaults; devnet observation will refine per-schema targets. Schemas can declare a preferred $T_\sigma$ at registration; the chain enforces governance bounds.]
+
+**Bounds.** $T_\sigma$ is bounded to $[0.1, 0.9]$ at the protocol level. A schema requesting $T_\sigma < 0.1$ is asking for $> 10 \times$ headroom over peak demand, which is wasteful; a schema requesting $T_\sigma > 0.9$ leaves no buffer for normal variance and would oscillate. Governance can adjust the bound but not the rate-limit (max one bound change per quarter).
 
 ### 4.3 Tip Mechanism
 
-[**v0.2:** Tip-as-priority within a schema's allocation. Tips go to the proposing validator (analogous to EIP-1559 priority fee).]
+Within a schema's allocated capacity, attestations are admitted in order of tip-per-attestation $\tau_\alpha$. Tips go to the proposing validator and are not subject to the base-fee burn (§4.4). The mechanism is identical in structure to EIP-1559's priority fee; per-schema partitioning means tips compete only against same-schema attestations.
+
+**Tip floor.** Schemas may declare a minimum tip $\tau_\sigma^{\min}$ at registration to prevent zero-fee spam. Default $\tau_\sigma^{\min} = 0$ (open to economic-signaling-only).
+
+**Tip auction within block.** The proposer admits attestations greedily by descending $\tau_\alpha$ until the schema's allocated capacity is filled. Ties broken by first-seen mempool ordering. The greedy auction is welfare-suboptimal compared to a sealed-bid second-price design but matches EIP-1559's actual deployment behavior; v2 extensions can revisit.
+
+**Sponsored gas (paymaster pattern).** Iris-style relayers pay tips on behalf of agents that don't hold $LGT$. The protocol semantics are unchanged: a single signed transaction can declare a *fee payer* address distinct from the *attestor* address. The fee payer pays both base fee and tip; the attestor signs the attestation content. This composes orthogonally with native delegation ([#5](https://github.com/ligate-io/ligate-research/issues/5)) — a delegated hot key can submit attestations whose fees are paid by a third-party paymaster. v2 of this paper details the formal fee-payer mechanism; v0.2 establishes that the design admits it cleanly.
 
 ### 4.4 Base-Fee Burn
 
-[**v0.2:** Burn fraction of base fee per attestation. Connection to PoUA's $\tau_{\text{burn}}$ (the §5.5.3 mechanism is computed against this paper's per-schema base fee, not a global value).]
+Of every paid base fee $b_\sigma \cdot |\alpha|$ for an admitted attestation $\alpha$ of schema $\sigma$:
+
+- A fraction $\tau_{\text{burn}}$ is burned (sent to the pure-burn destination per PoUA §5.5.3)
+- A fraction $1 - \tau_{\text{burn}}$ is rebated to the schema's fee-routing address (the registrant; up to 50% per `OVERVIEW.md`'s schema primitive)
+- Tips $\tau_\alpha$ are unaffected; they go to the proposing validator
+
+**Why the schema gets the non-burned fraction.** The schema registrant pays the registration fee at schema-creation, including the cost of operating their attestor set. Routing a fraction of base fees to the registrant aligns incentive: schemas that drive volume earn proportional ongoing revenue, which funds attestor-set operations and incentivizes schema curation. This is the "build a chain on top of Ligate" path: a partner registers a schema, pays the registration fee, and earns ongoing fee revenue from that schema's traffic.
+
+**Per-schema fee-routing parameter.** At registration, a schema declares its fee-routing fraction $\rho_\sigma \in [0, 0.5]$ (capped at 50% per protocol parameter). Effective burn is then:
+
+$$\text{burn}(\sigma) = \tau_{\text{burn}} + (1 - \tau_{\text{burn}}) \cdot (1 - \rho_\sigma)$$
+
+with the remainder $(1 - \tau_{\text{burn}}) \cdot \rho_\sigma$ routed to the schema registrant.
+
+**Interaction with PoUA $\tau_{\text{burn}}$ rebase.** $\tau_{\text{burn}}$ is the chain-wide burn fraction governed by PoUA §4.4.2's adaptive rebase. The per-schema $\rho_\sigma$ is set at registration and changes only via governance proposal. The two parameters are independent: $\tau_{\text{burn}}$ tracks economic-security drift, $\rho_\sigma$ tracks schema-builder economics.
+
+**Lemma 1 cost-to-grind preservation.** PoUA §5.5.3's Lemma 1 bounds adversary cost-to-grind as $F_{\text{net}} \geq \tau_{\text{burn}} \cdot \Delta r / (\eta \cdot \alpha_{\text{eff}})$. The per-schema fee market does not weaken this bound: even if every schema sets $\rho_\sigma = 0.5$, the burned fraction per attestation is at least $\tau_{\text{burn}} \cdot 0.5 \cdot b_\sigma$, and the cost-to-grind floor scales with that burned amount. The paper's central security claim survives the introduction of per-schema fee routing.
 
 ### 4.5 Integration with PoUA
 
-[**v0.2:** How the validator's per-schema fee preference interacts with PoUA reputation. Per-schema fee revenue feeds into the validator's $R_f$ in PoUA §6.3. Reputation is schema-agnostic: validator processes valid attestations across schemas, all count toward $g_v$.]
+The per-schema fee market interacts with PoUA reputation in three places.
+
+**Reputation accumulation is schema-agnostic.** Validators accumulate reputation $g_v$ from valid attestation work across all schemas, weighted by fee paid (PoUA §4.3):
+
+$$G_v^{\text{prop}}(t) = \sum_{B \in \text{Proposed}_v(t, t+E)} \sum_{\alpha \in B} \mathbb{1}[\alpha \text{ valid}] \cdot \text{fee}(\alpha)$$
+
+where $\text{fee}(\alpha) = b_\sigma + \tau_\alpha$ is the total fee paid (base + tip) for attestation $\alpha$ of schema $\sigma$. A validator who proposes blocks heavy in high-fee schema attestations accumulates reputation faster than one who specializes in low-fee schemas — but both accumulate strictly more than zero, preserving the §6.2 honest-equilibrium incentive structure.
+
+**Validator income decomposition.** Per PoUA §6.1, validator income from block $B$ at slot $t$ is:
+
+$$R_v(B, t) = R_b + \sum_{\alpha \in B} \tau_\alpha + \sum_{\alpha \in B} (1 - \tau_{\text{burn}}) \cdot (1 - \rho_{\sigma(\alpha)}) \cdot b_{\sigma(\alpha)}$$
+
+where $R_b$ is the protocol block reward, $\tau_\alpha$ is the per-attestation tip, and the third term is the validator's share of the per-schema base fee after burn and schema-routing. The validator's revenue depends on schema mix, but the §A.1 KL-divergence detector enforces that schema mix tracks the chain-wide null distribution; a validator preferentially including high-fee-schema attestations gets flagged.
+
+**Detector calibration accommodates per-schema fees.** PoUA §A.1 defines a KL-divergence detector against a chain-wide schema distribution null. With per-schema fees, validator-utility incentivizes schema-mix deviation; the detector calibration (see `prototypes/poua-sim/src/poua_sim/detectors.py`) tracks the actual per-schema arrival distribution. v0.2 of this paper specifies the joint calibration: detector null = empirical per-schema arrival distribution at the chain level, not at the validator level. v0.7.2 PoUA §A.1 already supports this; the per-schema fees mechanism does not require detector revision.
+
+**Sponsored gas does not inflate reputation.** Iris-style relayers paying base fees and tips on behalf of agents do not accumulate reputation themselves (they are not validators). The agent submitting the attestation gets credited (reputation accumulates against the *attestor*, not the *fee payer*); this matches the paper's intent that reputation tracks productive work, not financial sponsorship.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the v0.1 outline placeholders in §4 (Per-Schema Fee Mechanism) with substantive prose covering base-fee adjustment, target utilization calibration, tips, base-fee burn, and integration with PoUA reputation.

This is **v0.1.1** — partial v0.2 progress. §4 is now substantive; the rest of the paper remains v0.1 outline. Mirrors the same partial-progress pattern as native-da v0.1.1 ([#56](https://github.com/ligate-io/ligate-research/pull/56)).

## What's substantive in §4 now

### §4.1 Base-Fee Adjustment Formula (~50 lines)

- Per-schema EIP-1559 dynamics: $b_\sigma(t+1) = b_\sigma(t) \cdot (1 + \xi (u_\sigma - T_\sigma)/T_\sigma)$
- $\xi = 1/8$ recommended (matches EIP-1559)
- Allocated-slots-per-schema mechanism (fixed-share-per-schema as v0 default)
- Convergence + stability analysis (geometric decay around fixed point)
- First-order independence from PoUA τ_burn rebase (verified per spec §5.2 of η/λ rebase)

### §4.2 Target Utilization Calibration (~40 lines)

- Default $T_\sigma = 0.5$ (matches EIP-1559)
- Per-profile recommendations: stable / high-vol / bursty / real-time
- Bounds enforcement: $T_\sigma \in [0.1, 0.9]$ at protocol level
- Schema-declared preferences with governance bounds

### §4.3 Tip Mechanism (~35 lines)

- Tip-as-priority within schema allocation
- Tip floor $\tau_\sigma^{\min}$ at registration (default 0)
- Greedy-by-descending-tip auction (matches EIP-1559 deployment)
- **Sponsored gas (paymaster) pattern**: explicit fee-payer-distinct-from-attestor mechanism; composes orthogonally with native delegation (#5)

### §4.4 Base-Fee Burn (~50 lines)

- Burn fraction = $\tau_{\text{burn}}$ (chain-wide, governed by PoUA §4.4.2)
- Schema-routing fraction $\rho_\sigma \in [0, 0.5]$ at registration (the OVERVIEW.md "up to 50% to builder" primitive)
- Effective burn formula: $\text{burn}(\sigma) = \tau_{\text{burn}} + (1 - \tau_{\text{burn}})(1 - \rho_\sigma)$
- Lemma 1 cost-to-grind preservation: per-schema fee market does NOT weaken the security floor

### §4.5 Integration with PoUA (~50 lines)

- Reputation accumulation is schema-agnostic (validators count valid attestation work across all schemas)
- Validator income decomposition: $R_v = R_b + \tau_\alpha + (1 - \tau_{\text{burn}})(1 - \rho_\sigma) b_\sigma$
- §A.1 KL-divergence detector calibration accommodates per-schema fees (no detector revision needed)
- Sponsored gas does NOT inflate reputation (attestor gets credit, not fee-payer)

## What's still v0.1 placeholder

- §1 Introduction (heterogeneous-demand thesis, central question, contributions)
- §2 Background (EIP-1559, multi-resource fee markets, attestation chains)
- §3 System Model (schema as fee-market unit, validator income, demand profile taxonomy)
- §5 Security Analysis (cross-schema arbitrage, base-fee manipulation, fee-griefing, sponsored-gas adversarial patterns)
- §6 Incentive Analysis (validator / builder / sponsor)
- §7 Implementation in Ligate Chain (Sovereign SDK integration, v0 parameters, migration path)
- §8 Comparison with Prior Systems

## Verification

- Citation check: 43 citations ok across 17 paper files (was 41; +2 new cross-links in §4 to PoUA spec doc and detectors.py)
- README updated to v0.1.1 reflecting partial-progress status
- All formal expressions render in MathJax-aware viewers
- Lemma 1 preservation argument is informal (the proof would be a full §5.x section in v0.2)

## Why ship this now

§4 is the load-bearing mechanism section. With it substantive:

- §5 security analysis can attack a concrete formula rather than placeholder text
- §6 incentive analysis can decompose validator income against the formal $R_v$ expression
- §7 implementation has a target spec to integrate against
- The sponsored-gas (Iris paymaster) mechanism is now formally defined; this unblocks the Iris MCP relayer engineering conversations

The mechanism is design-determined rather than measurement-dependent. Devnet measurements will refine $T_\sigma$ defaults and per-schema $\rho_\sigma$ calibration but won't change the formulae.

## What this PR does NOT do

- Touch any other paper
- Modify simulator code
- Generate PDF (deferred to full v0.2 with all sections substantive)
- Address §5 security analysis or §6 incentive analysis (those build on §4 in v0.2 proper)

## Test plan

- [x] Citation check passes
- [x] Markdown renders cleanly
- [x] All cross-references to PoUA paper sections + spec doc resolve
- [x] §4.4 Lemma 1 preservation argument is consistent with PoUA v0.7.2 §5.5.3
- [ ] Reviewer reads §4 and either (a) approves the mechanism design, or (b) flags a specific formula

## Related

- [#4](https://github.com/ligate-io/ligate-research/issues/4): umbrella research issue
- [#40](https://github.com/ligate-io/ligate-research/issues/40): v0.2 milestone tracker (this PR closes the §4 line item)
- [#33](https://github.com/ligate-io/ligate-research/pull/33): v0.1 outline scaffold (predecessor)
- PoUA v0.7.2 §4.4.2 (adaptive τ_burn rebase that this paper composes with)
- PoUA v0.7.2 §5.5.3 (Lemma 1 cost-to-grind that this paper preserves)
- PoUA v0.8 §4.4.3 working spec at `papers/poua/specs/eta-lambda-rebase.md` (the §5.2 first-order independence argument that this paper relies on)

This PR represents ~3 hours of focused writing — §4 in full, README updated to v0.1.1.