### PR TITLE
v0.2 notation renames: native-da $\Lambda \to A$, native-delegation $\rho \to \gamma$

### DIFF
--- a/papers/CONSISTENCY_REVIEW.md
+++ b/papers/CONSISTENCY_REVIEW.md
@@ -149,14 +149,14 @@ cross-schema-composition §3 does not mention time-locked-attestations or per-sc
 
 ## 5. Recommended actions
 
-### 5.1 Inline fixes in this PR
+### 5.1 Inline fixes (applied)
 
-- [x] cross-schema-composition: rename graph $G \to \mathcal{G}$ (3 occurrences in §3.2, §3.4 placeholder). Mechanical.
+- [x] cross-schema-composition: rename graph $G \to \mathcal{G}$ (PR #63, 2 occurrences). Mechanical.
+- [x] native-da §3.2: rename $\Lambda(t) \to A(t)$ for aggregate throughput (PR #64, 7 occurrences). Avoids PoUA $\Lambda_i$ overload.
+- [x] native-delegation §5.5: rename risk-aversion $\rho \to \gamma$ (PR #64, 10 occurrences). Avoids PoUA $\rho$ stake-share overload.
 
 ### 5.2 v0.2 paper-cycle items (will land alongside reviewer feedback)
 
-- [ ] native-da §3.2: rename $\Lambda(t) \to A(t)$ for aggregate throughput (avoids PoUA $\Lambda_i$ overload)
-- [ ] native-delegation §5.5: rename risk-aversion $\rho \to \gamma$ (avoids PoUA $\rho$ stake-share overload)
 - [ ] per-schema-fees §4.3: anchor to native-delegation §4.1 `MsgDelegate` once that lands substantive
 - [ ] native-delegation §7: forward-reference per-schema-fees §4.3 paymaster pattern in Iris Integration
 - [ ] cross-schema-composition §6: add use cases referencing time-locked-attestations and per-schema-fees as graph edges

--- a/papers/native-da/native-da.md
+++ b/papers/native-da/native-da.md
@@ -160,26 +160,26 @@ $$N_\sigma(t) \sim \text{Poisson}(\lambda_\sigma t)$$
 
 where $\lambda_\sigma$ is the per-schema arrival rate. Aggregate chain throughput is the sum over schemas:
 
-$$\Lambda(t) = \sum_\sigma \lambda_\sigma$$
+$$A(t) = \sum_\sigma \lambda_\sigma$$
 
-**Bursts vs sustained.** A characterizing property of attestation traffic, distinct from blob-rollup traffic, is that $\Lambda(t)$ is **sustained** rather than bursty. Rollup chains post a single multi-MB blob per block at a frequency determined by block time; the inter-blob arrival is bursty by construction. Attestation arrivals are continuous: each user action (a ChatGPT prompt, a wallet transfer, an agent action) generates an attestation independently. The arrival rate has diurnal and weekly cycles but is otherwise steady.
+**Bursts vs sustained.** A characterizing property of attestation traffic, distinct from blob-rollup traffic, is that $A(t)$ is **sustained** rather than bursty. Rollup chains post a single multi-MB blob per block at a frequency determined by block time; the inter-blob arrival is bursty by construction. Attestation arrivals are continuous: each user action (a ChatGPT prompt, a wallet transfer, an agent action) generates an attestation independently. The arrival rate has diurnal and weekly cycles but is otherwise steady.
 
 This is closer to a high-write-rate database than a blob-storage workload.
 
 **Calibration targets.**
 
-| Phase | Aggregate $\Lambda$ (atts/sec) | Driver | Block size implication |
+| Phase | Aggregate $A$ (atts/sec) | Driver | Block size implication |
 |---|---|---|---|
 | v0 devnet | 50-100 | Themisra design partners + early adopters | ~0.5 MB/block at 12-sec blocks (median size) |
 | v1 mainnet (year 1) | 200-500 | Themisra + Mneme + Kleidon launches | ~2 MB/block |
 | v2 mainnet (year 2-3) | 1000-5000 | Iris agent traffic dominates; 100s of agents per user | ~20 MB/block at sustained peak |
 | v3 mature | 10000+ | Full agent ecosystem; AI-action attestation per second per user | ~100 MB/block; native DA becomes binding |
 
-[**Measured at v0.2.5+:** these are calibration targets, not predictions. Devnet measurement at v0.2.5 will firm up the v0 row; subsequent revisions will track aggregate $\Lambda$ as adoption progresses.]
+[**Measured at v0.2.5+:** these are calibration targets, not predictions. Devnet measurement at v0.2.5 will firm up the v0 row; subsequent revisions will track aggregate $A$ as adoption progresses.]
 
-**Variance and tail behavior.** Under a Poisson process, the per-block attestation count $N_{\text{block}}$ has standard deviation $\sqrt{\lambda \cdot E}$ where $E$ is the block time. At $\Lambda = 1000$ atts/sec and $E = 12$ sec, expected block count is 12,000 with standard deviation $\approx 110$, a coefficient of variation $\approx 1\%$. This means block sizing can be tight (p99 block size $\approx 1.025 \cdot$ mean), a meaningful efficiency advantage over bursty workloads where p99/mean ratios of 5× to 10× are common.
+**Variance and tail behavior.** Under a Poisson process, the per-block attestation count $N_{\text{block}}$ has standard deviation $\sqrt{\lambda \cdot E}$ where $E$ is the block time. At $A = 1000$ atts/sec and $E = 12$ sec, expected block count is 12,000 with standard deviation $\approx 110$, a coefficient of variation $\approx 1\%$. This means block sizing can be tight (p99 block size $\approx 1.025 \cdot$ mean), a meaningful efficiency advantage over bursty workloads where p99/mean ratios of 5× to 10× are common.
 
-**Per-validator bandwidth.** A validator must serve sample requests for the rolling DA window plus per-block tally work. At v3 sustained peak ($\Lambda = 10000$, 100 MB/block), per-validator bandwidth is dominated by block ingestion rather than DA sampling overhead. The native DA design (§7) provides the bandwidth-per-validator analysis under the stated workload.
+**Per-validator bandwidth.** A validator must serve sample requests for the rolling DA window plus per-block tally work. At v3 sustained peak ($A = 10000$, 100 MB/block), per-validator bandwidth is dominated by block ingestion rather than DA sampling overhead. The native DA design (§7) provides the bandwidth-per-validator analysis under the stated workload.
 
 ### 3.3 Ordering Requirements
 
@@ -223,7 +223,7 @@ Warm tier supports historical inclusion checks: a regulator auditing a 6-month-o
 
 Cold tier supports attestor-history queries: "did $X$ sign in schema $\sigma$ at epoch $t$?" answered by per-epoch summary commitments. Minimal storage cost (one commitment per schema per epoch); supports indefinite retention.
 
-**Storage cost analysis.** Per-validator storage at v2 sustained peak ($\Lambda = 1000$, median size 400 B):
+**Storage cost analysis.** Per-validator storage at v2 sustained peak ($A = 1000$, median size 400 B):
 
 - Hot tier (30 days): $1000 \cdot 400 \cdot 86400 \cdot 30 \approx 1$ TB
 - Warm tier (1 year): per-schema-commitment is $\approx 32$ B per attestation; $1000 \cdot 32 \cdot 86400 \cdot 365 \approx 1$ TB

--- a/papers/native-delegation/native-delegation.md
+++ b/papers/native-delegation/native-delegation.md
@@ -222,17 +222,17 @@ We now show that under standard EV-maximizing adversary assumptions, the both-sl
 - $G_{\text{hot}}$: hot-key operator's per-grant utility (positive; covers operational fee revenue)
 - $p_c \in (0, 1)$: probability the hot key is compromised within the grant window
 - $\Lambda$: per-slash severity in PoUA reputation units
-- $\rho$: master's risk-aversion coefficient over reputation loss; $\rho > 1$ for typical risk-averse users
+- $\gamma$: master's risk-aversion coefficient over reputation loss; $\gamma > 1$ for typical risk-averse users
 
 **Properties to satisfy.**
 
 **(P1) Master accepts delegation under typical conditions.** Master's expected utility from delegation must be non-negative:
 
-$$\mathbb{E}[U_{\text{master}}] = G_{\text{delegate}} - \rho \cdot p_c \cdot w_m \cdot \Lambda \geq 0$$
+$$\mathbb{E}[U_{\text{master}}] = G_{\text{delegate}} - \gamma \cdot p_c \cdot w_m \cdot \Lambda \geq 0$$
 
 **(P2) Master incentivized to monitor.** Master's marginal disutility from a hot-key compromise must be strictly positive:
 
-$$\frac{\partial \mathbb{E}[U_{\text{master}}]}{\partial p_c} = -\rho \cdot w_m \cdot \Lambda < 0 \implies w_m > 0$$
+$$\frac{\partial \mathbb{E}[U_{\text{master}}]}{\partial p_c} = -\gamma \cdot w_m \cdot \Lambda < 0 \implies w_m > 0$$
 
 **(P3) Hot-key operator faces cost.** Hot-key operator's expected utility must internalize compromise probability:
 
@@ -248,15 +248,15 @@ This prevents adversaries from triggering one slash and damaging both parties by
 
 **Theorem 1 (Slashing-Inheritance Optimality).** Under (P1)-(P4), the both-slashed rule with weights $(w_m, w_h)$ satisfying
 
-$$w_m + w_h = 1, \quad 0 < w_h < w_m, \quad w_m \geq \frac{G_{\text{delegate}}}{\rho \cdot p_c \cdot \Lambda}$$
+$$w_m + w_h = 1, \quad 0 < w_h < w_m, \quad w_m \geq \frac{G_{\text{delegate}}}{\gamma \cdot p_c \cdot \Lambda}$$
 
-is feasible. Master-only ($w_m = 1, w_h = 0$) violates (P3); hot-only ($w_m = 0, w_h = 1$) violates (P2); equal-split ($w_m = w_h = 0.5$) violates (P1) at typical $\rho > 2$.
+is feasible. Master-only ($w_m = 1, w_h = 0$) violates (P3); hot-only ($w_m = 0, w_h = 1$) violates (P2); equal-split ($w_m = w_h = 0.5$) violates (P1) at typical $\gamma > 2$.
 
-**Proof.** Master-only sets $w_h = 0$, violating $w_h > 0$ in (P3). Hot-only sets $w_m = 0$, violating $w_m > 0$ in (P2). Equal-split with $w_m = w_h = 0.5$ requires $G_{\text{delegate}} \geq \rho \cdot p_c \cdot 0.5 \cdot \Lambda$ for (P1); at typical risk aversion $\rho \approx 3$ and modest compromise probability $p_c = 0.05$ over a 24-hour grant window, this requires $G_{\text{delegate}} \geq 0.075 \cdot \Lambda$, which is rare for low-utility delegations (e.g., a user delegating to an AI agent for a single task worth $\$0.50$ should not face a $\$50$ reputation-equivalent risk).
+**Proof.** Master-only sets $w_h = 0$, violating $w_h > 0$ in (P3). Hot-only sets $w_m = 0$, violating $w_m > 0$ in (P2). Equal-split with $w_m = w_h = 0.5$ requires $G_{\text{delegate}} \geq \gamma \cdot p_c \cdot 0.5 \cdot \Lambda$ for (P1); at typical risk aversion $\gamma \approx 3$ and modest compromise probability $p_c = 0.05$ over a 24-hour grant window, this requires $G_{\text{delegate}} \geq 0.075 \cdot \Lambda$, which is rare for low-utility delegations (e.g., a user delegating to an AI agent for a single task worth $\$0.50$ should not face a $\$50$ reputation-equivalent risk).
 
 The both-slashed family with $w_m + w_h = 1$ and $w_m > w_h$ provides:
 
-- (P1): satisfied at $w_m = 1 - w_h$ for $G_{\text{delegate}} \geq \rho \cdot p_c \cdot (1 - w_h) \cdot \Lambda$. Smaller $w_h$ relaxes the constraint.
+- (P1): satisfied at $w_m = 1 - w_h$ for $G_{\text{delegate}} \geq \gamma \cdot p_c \cdot (1 - w_h) \cdot \Lambda$. Smaller $w_h$ relaxes the constraint.
 - (P2): trivially $w_m > w_h > 0$ and so $w_m > 0$.
 - (P3): $w_h > 0$.
 - (P4): $w_m + w_h = 1$ exactly satisfies the constraint at the boundary.
@@ -284,7 +284,7 @@ This satisfies the theorem's requirements ($w_m + w_h = 1$, $0 < w_h < w_m$) whi
 
 **Comparison with PoS chains.** Cosmos chains using `x/authz` apply slashing to the granter (master-only equivalent). Ethereum's ERC-4337 has no native slashing. Solana's fee-payer pattern has no reputation surface. Our both-slashed rule is the first runtime-primitive specification of split-reputation slashing tied to an explicit theorem.
 
-**Empirical validation.** The simulator scaffold at `prototypes/native-delegation-sim/` (planned in v0.2) will exercise the theorem against rational-adversary strategy search across $(w_m, w_h)$ pairs, empirically confirming Theorem 1's predictions across a range of $\rho$ and $p_c$ values.
+**Empirical validation.** The simulator scaffold at `prototypes/native-delegation-sim/` (planned in v0.2) will exercise the theorem against rational-adversary strategy search across $(w_m, w_h)$ pairs, empirically confirming Theorem 1's predictions across a range of $\gamma$ and $p_c$ values.
 
 ---
 


### PR DESCRIPTION
## Summary

Applies the two v0.2 notation follow-ups from CONSISTENCY_REVIEW.md §5.2 inline. Both are mechanical symbol renames driven by the cross-paper consistency review:

- **native-da §3.2**: $\Lambda(t) \to A(t)$ for aggregate attestation throughput. Avoids overload with PoUA's $\Lambda_i$ slash severities.
- **native-delegation §5.5**: $\rho \to \gamma$ for master's risk-aversion coefficient. Avoids overload with PoUA's $\rho$ adversary stake share.

Updates CONSISTENCY_REVIEW.md to reflect both inline fixes.

## Replacements

- `papers/native-da/native-da.md`: 7 instances of `\Lambda` → `A`
- `papers/native-delegation/native-delegation.md`: 10 instances of `\rho` → `\gamma`

Both renames are isolated to the v0.1.1-substantive sections (native-da §3 workload model, native-delegation §5 slashing-inheritance theorem). No other files affected.

## Why these renames

From CONSISTENCY_REVIEW.md §1:

**$\Lambda$ overload (severity: low)**: PoUA §4.5 uses $\Lambda_i$ for slash severities; native-da §3.2 used $\Lambda(t)$ for aggregate throughput. Distinct concepts, but a reader cross-referencing the two papers could confuse them. Renaming to $A(t)$ is mechanical and removes the ambiguity. $A$ for "attestations per second" is intuitive.

**$\rho$ overload (severity: medium)**: PoUA §5.3 uses bare $\rho$ for adversary stake share; native-delegation §5.5 used bare $\rho$ for risk-aversion coefficient. The two definitions appear in the same Theorem 1 proof (which references PoUA reputation units while reasoning about utility functions). Renaming to $\gamma$ is the standard utility-theory convention for risk-aversion (matches Arrow-Pratt notation).

The PoUA paper is unchanged; subsequent papers conform to PoUA's existing notation.

## What's NOT renamed

- $\rho_{\text{vol}}$ (PoUA volume-deterrent ratio): subscripted, distinct
- $\rho_\sigma$ (per-schema-fees fee-routing fraction): subscripted, distinct
- $\Lambda_i$ (PoUA slash severities): subscripted, distinct

These were never in conflict; only bare $\rho$ and bare $\Lambda(t)$ needed renaming.

## Verification

- Citation check: 44 citations ok across 18 paper files (no change)
- Zero em dashes (verified)
- Theorem 1 in native-delegation §5.5 still parses correctly with $\gamma$ everywhere
- $A(t) = \sum_\sigma \lambda_\sigma$ in native-da §3.2 reads cleanly
- CONSISTENCY_REVIEW.md updated: §5.1 now lists three completed inline fixes

## What this PR does NOT do

- Touch PoUA paper (no rename needed there)
- Add the 3 forward-reference items in CONSISTENCY_REVIEW §5.2 (those wait until destination sections become substantive)
- Modify simulator code (no notation overlap there)

## Test plan

- [x] Citation check passes
- [x] Zero em dashes
- [x] Theorem 1 statement reads consistently with $\gamma$ throughout
- [x] §3.2 throughput discussion in native-da reads consistently with $A(t)$
- [x] CONSISTENCY_REVIEW.md updated to reflect completed status
- [ ] Reviewer reads §5 of native-delegation and §3.2 of native-da with renames in mind

## Related

- [#63](https://github.com/ligate-io/ligate-research/pull/63): cross-paper consistency review (this PR's source recommendations)
- CONSISTENCY_REVIEW.md §1.1, §1.2, §5.1