### PR TITLE
Reading guides for 5 supplementary papers

### DIFF
--- a/papers/cross-schema-composition/READING_GUIDE.md
+++ b/papers/cross-schema-composition/READING_GUIDE.md
@@ -1,0 +1,55 @@
+# Cross-Schema Composition: Reading Guide
+
+A 1-page wayfinder for readers approaching the cross-schema-composition paper.
+
+This paper is at v0.1.1 with §3 + §4 substantive; the rest is v0.1 outline scaffold. **Explicitly v2 protocol territory**, not v1. v0.2 authoring is gated on 2-3 design-partner use cases.
+
+## What this paper specifies
+
+Chain-enforced typing for attestation references and slashing-aware proof propagation through the schema dependency graph. Schemas declare typed input dependencies; the runtime rejects malformed references at attestation-time and propagates slashes through dependents.
+
+## Where to start (by background)
+
+| Background | Start here |
+|---|---|
+| **Type systems / dependent types** | §3.1 schemas as typed graphs (formal $\sigma = (I_\sigma, O_\sigma, P_\sigma, \mathcal{A}_\sigma, V_\sigma)$); §4.3 type predicate (deterministic, gas-bounded, total) |
+| **EAS / attestation graphs** | §2.2 EAS schema graph background; §1.3 type-confusion problem (the gap EAS leaves application-level) |
+| **Capability-secure languages** | §2.3 capability-secure systems (E, Pony, Joe-E); §4.2 input-type set as compile-time-style capability |
+| **Cascading invalidation / DB systems** | §3.4 validity state machine (VALID + 3 terminal states); §5 slashing propagation (strict / lazy / configurable cascade rules) |
+| **PoUA / Ligate runtime** | §3.3 attestation as witness (composes with PoUA §3 attestation primitive); §4.4 runtime type-check pipeline (6 admission steps) |
+
+## Load-bearing claims
+
+1. **Chain-enforced typing (§4.4)**: type checks happen at attestation-time, not application-time. Type-confusion attacks are rejected at mempool admission, not at consumer read-time.
+
+2. **Slashing propagation (§5)**: when a referenced attestation transitions out of VALID, dependents are notified per the cascade rule (strict / lazy / configurable). Runtime guarantees deterministic propagation.
+
+3. **Acyclicity by default (§3.2)**: dependency graph $\mathcal{G} = (\Sigma, E)$ is acyclic; cycles rejected at registration via topological sort. Opt-in cyclic mode for advanced use cases (§5.6).
+
+4. **Subtyping for backward-compatible upgrades (§4.5)**: structural-superset payloads + weakened predicates allow $V = k+1$ to substitute for $V = k$ without breaking dependents.
+
+## What's substantive at v0.1.1
+
+§3 (System Model) and §4 (Type System). §1, §2, §5+ remain v0.1 outline.
+
+## What v0.2 will add
+
+Per the [v0.2 milestone tracker (#44)](https://github.com/ligate-io/ligate-research/issues/44):
+
+- §1 introduction, §2 background substantive
+- §5 slashing propagation (cascade rules with termination theorem)
+- §6 use cases (THE gate: 2-3 design-partner-validated examples)
+- §7 comparison (Ethereum contracts, EAS, capability languages, IBC)
+- §8 security analysis (type-confusion, slash-amplification, cycle DoS)
+- §A simulator scaffolding
+
+**v0.2 explicitly waits on design-partner validation.** Without 2-3 concrete use cases, this paper stays at v0.1.1. "Schemas as composable Lego" is a vibe, not a use case.
+
+## How to send feedback
+
+Open an issue against `ligate-research` with label `paper-composition`. Specifically valuable: concrete use cases that need this primitive (could become §6 entries), or critique of the §3-§4 formal model.
+
+## Contact
+
+- Email: hello@ligate.io
+- Repo: [ligate-io/ligate-research](https://github.com/ligate-io/ligate-research)

--- a/papers/native-da/READING_GUIDE.md
+++ b/papers/native-da/READING_GUIDE.md
@@ -1,0 +1,56 @@
+# Native DA Layer: Reading Guide
+
+A 1-page wayfinder for readers approaching the native-da paper.
+
+This paper is at v0.1.1 with §3 substantive; the rest is v0.1 outline scaffold. **Explicitly not** an advocacy paper for leaving Celestia. Ligate stays on Celestia through v1.
+
+## What this paper specifies
+
+An attestation-optimized data availability layer with per-schema indexed commitments, attestor-history queries, and fee-market integration with PoUA $\tau_{\text{burn}}$. Positioned as a long-horizon migration target with concrete decision criteria (§12) for if and when migration is worth it.
+
+## Where to start (by background)
+
+| Background | Start here |
+|---|---|
+| **Celestia / DA layers** | §2 background (Celestia, EigenDA, Avail, Walrus, 0G); §4 why specialization (counter-arguments included) |
+| **Workload modeling** | §3.1 size distribution per schema; §3.2 throughput profile; §3.5 query patterns |
+| **Erasure coding / commitment schemes** | §6.1 per-schema commitment trees (KZG vs Verkle vs namespace Merkle); §6.3 BLS aggregation tradeoff |
+| **PoUA cryptoeconomics** | §9 fee market (per-byte vs per-attestation; burn-share interaction with PoUA $\tau_{\text{burn}}$ rebase) |
+| **Migration strategy** | §11 native-vs-Celestia-vs-hybrid comparison; §12 migration decision criteria |
+
+## Load-bearing claims
+
+1. **Workload mismatch (§3 + §4)**: attestations are 200-800 bytes, sustained-throughput, signature-heavy. Celestia is tuned for blob-shaped traffic (4 KB+ shares, bursty). Quantitative gap measurable.
+
+2. **Per-schema indexing benefit (§3.5 + §6.1)**: attestor-history queries ("did $X$ sign in epoch $t$?") cost $O(\log d)$ with per-schema commitment trees vs $O(\text{full-namespace-scan})$ on Celestia.
+
+3. **Migration decision (§12)**: 2-of-4 trigger criteria. Default state is "stay on Celestia"; migration only when concrete pre-conditions fire.
+
+4. **Stance is non-advocacy (§1.9)**: the paper exists to enable a deliberate migration decision if conditions change, not to advocate for migration.
+
+## What's substantive at v0.1.1
+
+§3 (Workload Model) only. §1, §2, §4-§14 remain v0.1 outline.
+
+§3 includes: log-normal size distribution model with expected values for 7 flagship schemas; Poisson throughput model with calibration targets v0→v3; ordering requirements with formal partial-order definition; three-tier retention (hot/warm/cold); three dominant query patterns. Numerical values flagged `[**Measured at v0.2.5+:**]` for devnet refinement.
+
+## What v0.2 will add
+
+Per the [v0.2 milestone tracker (#42)](https://github.com/ligate-io/ligate-research/issues/42):
+
+- §1 introduction (thesis + non-advocacy stance)
+- §5 system model, §6 mechanism (commitment scheme decision), §7 consensus design
+- §8 light-client protocol (the new attestor-history-query primitive)
+- §9 fee market, §10 security analysis, §11 native-vs-Celestia comparison
+- §12 migration decision criteria with concrete thresholds
+
+v0.2 ships when one of: Celestia raises fees materially, Celestia governance shifts incompatibly, or workload mismatch surfaces a binding bottleneck.
+
+## How to send feedback
+
+Open an issue against `ligate-research` with label `paper-da`. The §3 workload model is the most useful target for empirical-grounding critique; the §1.9 non-advocacy stance is the most useful target for strategic critique.
+
+## Contact
+
+- Email: hello@ligate.io
+- Repo: [ligate-io/ligate-research](https://github.com/ligate-io/ligate-research)

--- a/papers/native-delegation/READING_GUIDE.md
+++ b/papers/native-delegation/READING_GUIDE.md
@@ -1,0 +1,57 @@
+# Native Delegation: Reading Guide
+
+A 1-page wayfinder for readers approaching the native-delegation paper.
+
+This paper is at v0.1.1 with §5 substantive; the rest is v0.1 outline scaffold. External review will not be solicited until v1.0.
+
+## What this paper specifies
+
+Hot-key / master-key separation as a runtime primitive on Ligate Chain. Delegation grants are protocol-level (not smart contracts); slashing inheritance is governed by **Theorem 1** with recommended weights $(w_m, w_h) = (0.7, 0.3)$.
+
+This is the foundational paper for the **Iris MCP relayer**: agents act on behalf of users via delegated hot keys without holding the user's master key.
+
+## Where to start (by background)
+
+| Background | Start here |
+|---|---|
+| **Mechanism design / utility theory** | §5.5 Theorem 1 (Slashing-Inheritance Optimality) with proof; key insight: $w_m + w_h = 1$ with $w_m > w_h$ is uniquely feasible under (P1)-(P4) |
+| **ERC-4337 / smart-contract wallets** | §1.3 contract-vs-runtime tradeoff; §2.1 ERC-4337 background; §6 native-vs-contract comparison (v0.2) |
+| **Cosmos authz / x/authz** | §2.3 Cosmos authz background; closest existing analog with master-only-style slashing |
+| **Iris / agent infrastructure** | §5.6 recommended v0 calibration; §7 Iris integration (v0.2); the paper informs Iris engineering directly |
+| **PoUA cryptoeconomics** | §5 slashing inheritance; integrates with PoUA §4.3 reputation update |
+
+## Load-bearing claims
+
+1. **Theorem 1 (§5.5)**: under risk-aversion $\gamma > 1$ and EV-maximizing adversaries, the both-slashed rule with $w_m + w_h = 1$, $0 < w_h < w_m$ is uniquely feasible. Master-only and hot-only fail key incentive properties; equal-split fails risk-budget property.
+
+2. **Recommended calibration (§5.6)**: $(w_m, w_h) = (0.7, 0.3)$ is the v0 default. Master bears 70% of slash severity; hot key bears 30%. Schemas can override within governance bounds.
+
+3. **Runtime not contract (§1.3)**: delegation is a protocol-level primitive, not a smart contract. PoUA reputation accounting requires this.
+
+4. **Iris orthogonal to slashing (§7)**: Iris-style sponsored-gas relayers compose with delegation; the relayer pays fees but the attestor (delegated hot key) accrues reputation per PoUA §4.3.
+
+## What's substantive at v0.1.1
+
+§5 only. §1, §2, §3, §4, §6+ remain v0.1 outline.
+
+## What v0.2 will add
+
+Per the [v0.2 milestone tracker (#41)](https://github.com/ligate-io/ligate-research/issues/41):
+
+- §1 introduction, §2 background, §3 system model substantive
+- §4 mechanism specification (`MsgDelegate`, `MsgRevokeDelegate`, validation rules, lifecycle)
+- §6 native-vs-contract comparison
+- §7 Iris MCP relayer integration
+- §8 security analysis (5 threat models)
+- §A simulator scaffolding under [`prototypes/native-delegation-sim/`](../../prototypes/native-delegation-sim/) (scaffold landed in PR #65)
+
+v0.2 ships when Iris MCP relayer engineering reaches design-doc phase.
+
+## How to send feedback
+
+Open an issue against `ligate-research` with label `paper-delegation`. The Theorem 1 statement and proof are the highest-leverage targets for critique.
+
+## Contact
+
+- Email: hello@ligate.io
+- Repo: [ligate-io/ligate-research](https://github.com/ligate-io/ligate-research)

--- a/papers/per-schema-fees/READING_GUIDE.md
+++ b/papers/per-schema-fees/READING_GUIDE.md
@@ -1,0 +1,50 @@
+# Per-Schema Fee Markets: Reading Guide
+
+A 1-page wayfinder for readers approaching the per-schema-fees paper.
+
+This paper is at v0.1.1 with §4 substantive; the rest is v0.1 outline scaffold. External review will not be solicited until v1.0.
+
+## What this paper specifies
+
+Per-schema EIP-1559-style fee markets. Each registered schema $\sigma$ carries its own base fee $b_\sigma$, target utilization $T_\sigma$, and adjustment dynamics. Tips $\tau_\alpha$ go to the proposer; base fees split between burn (governed by PoUA $\tau_{\text{burn}}$) and schema-routing fraction $\rho_\sigma$.
+
+## Where to start (by background)
+
+| Background | Start here |
+|---|---|
+| **EIP-1559 / fee markets** | §4.1 base-fee adjustment formula (per-schema EIP-1559); §4.2 target utilization calibration |
+| **PoUA cryptoeconomics** | §4.4 base-fee burn (interaction with PoUA $\tau_{\text{burn}}$); §4.5 reputation accrual |
+| **Sponsored-gas / paymaster** | §4.3 tip mechanism (sponsored-gas pattern); composes with native-delegation #5 |
+| **Iris MCP relayer engineering** | §4.3 paymaster pattern; v0.2 §6.3 will detail Iris-specific use cases |
+
+## Load-bearing claims
+
+1. **Per-schema isolation**: high-utilization schema cannot drag down low-utilization schema's base fee (§4.1 convergence argument)
+2. **Lemma 1 preservation**: per-schema fee market does NOT weaken PoUA's cost-to-grind floor, even with $\rho_\sigma = 0.5$ schema-routing (§4.4)
+3. **First-order independence with PoUA $\tau_{\text{burn}}$ rebase**: schema-fee drift and cost-to-grind drift are separate signals (§4.1)
+4. **Sponsored-gas orthogonality**: composes with native delegation without re-introducing reputation-attribution issues (§4.3, §4.5)
+
+## What's substantive at v0.1.1
+
+§4 only. §1, §2, §3, §5+ remain v0.1 outline.
+
+## What v0.2 will add
+
+Per the [v0.2 milestone tracker (#40)](https://github.com/ligate-io/ligate-research/issues/40):
+
+- §1-§3 substantive (introduction, background, system model)
+- §5 security analysis (cross-schema arbitrage, fee-griefing)
+- §6 incentive analysis (validator / builder / sponsor)
+- §7 implementation in Ligate Chain
+- §A simulator scaffolding
+
+v0.2 ships when PoUA reaches v0.8+, devnet shows non-trivial schema volume, and a fee-market expert is engaged.
+
+## How to send feedback
+
+Comment on the paper directly: open an issue against `ligate-research` with label `paper-fees`. Substantive critique appreciated; questions appreciated; "looks reasonable" appreciated.
+
+## Contact
+
+- Email: hello@ligate.io
+- Repo: [ligate-io/ligate-research](https://github.com/ligate-io/ligate-research)

--- a/papers/time-locked-attestations/READING_GUIDE.md
+++ b/papers/time-locked-attestations/READING_GUIDE.md
@@ -1,0 +1,59 @@
+# Time-Locked Attestations: Reading Guide
+
+A 1-page wayfinder for readers approaching the time-locked-attestations paper.
+
+This paper is at v0.1.1 with §4 substantive; the rest is v0.1 outline scaffold. **v1.5 protocol territory**: v1 of Ligate Chain ships single-phase attestations only. v0.2 authoring is gated on at least one design-partner use case per category.
+
+## What this paper specifies
+
+Commit-reveal as a runtime primitive. A schema field `reveal_at` declares the block height after which the payload becomes valid. Three transaction types (`MsgCommit` / `MsgReveal` / `MsgCleanup`) plus deposit-on-commit and batched-reveal sequencing for front-running defense.
+
+Three target use-case categories: sealed-bid auctions, embargoed announcements, regulatory time-locks.
+
+## Where to start (by background)
+
+| Background | Start here |
+|---|---|
+| **Cryptographic commitments** | §3.4 hash function and nonce length; §5.1 binding theorem; §5.2 hiding theorem; §5.3 nonce entropy bound |
+| **On-chain auctions / Vickrey** | §2.2 on-chain auction background; §6.2 sealed-bid auction use case (v0.2); §4.4 deposit-on-commit (anti-spam mechanism) |
+| **MEV / front-running** | §4.5 front-running defense via batched-reveal sequencing; cross-block races and validator-collusion limitations acknowledged |
+| **Embargo / regulatory** | §6.3 embargoed announcement use case (v0.2); §6.4 regulatory time-lock use case (v0.2) |
+| **Drand / VDF / time-lock encryption** | §2.4 time-locked encryption background; §9.3 VDF future work (out of scope for v0.2) |
+
+## Load-bearing claims
+
+1. **Commit-reveal eliminates trusted auctioneer (§1.2)**: off-chain protocols require a trusted intermediary; on-chain commit-reveal eliminates that trust at the cost of chain state.
+
+2. **Front-running defense via sequencing (§4.5)**: reveals are sequenced before any new commits in the same block. A reveal observer cannot beat the original to settlement within a block.
+
+3. **Cryptographic security under standard assumptions (§5)**: binding reduces to second-preimage resistance of $H$; hiding reduces to preimage resistance under nonce entropy bound.
+
+4. **TTL + deposit prevent never-reveal spam (§4.3, §4.4)**: cleanup is fee-incentivized; deposits create economic incentive to actually reveal.
+
+## What's substantive at v0.1.1
+
+§4 (Mechanism) only. §1, §2, §3, §5+ remain v0.1 outline.
+
+§4 includes: full `MsgCommit` / `MsgReveal` / `MsgCleanup` schemas with admission validation; commitment lifecycle state machine; deposit-on-commit policy with 4 destination options; front-running defense formal specification.
+
+## What v0.2 will add
+
+Per the [v0.2 milestone tracker (#46)](https://github.com/ligate-io/ligate-research/issues/46):
+
+- §1 introduction, §2 background, §3 system model substantive
+- §5 cryptographic security (binding, hiding, nonce-entropy bounds)
+- §6 use cases: **one design-partner-validated example per category** (auction, embargo, regulatory)
+- §7 comparison (off-chain commit-reveal, on-chain auction contracts, ZK-based time-locks)
+- §8 failure modes
+- §A simulator scaffolding
+
+**v0.2 explicitly waits on design-partner validation.** Without one partner per category, this paper stays at v0.1.1.
+
+## How to send feedback
+
+Open an issue against `ligate-research` with label `paper-timelock`. Specifically valuable: concrete use cases from any of the three target categories (could become §6 entries), or critique of the §4 mechanism (especially the front-running defense).
+
+## Contact
+
+- Email: hello@ligate.io
+- Repo: [ligate-io/ligate-research](https://github.com/ligate-io/ligate-research)


### PR DESCRIPTION
Five 1-page wayfinder docs mirroring the PoUA reading guide pattern. Each covers: what the paper specifies, where to start by background, load-bearing claims, what's substantive at v0.1.1, what v0.2 will add, how to send feedback. Citation check 44 ok across 23 paper files. Zero em dashes.