### PR TITLE
Add verifiable-content-provenance + themisra-licensing-schemas v0.0 papers

### DIFF
--- a/papers/README.md
+++ b/papers/README.md
@@ -2,18 +2,29 @@
 
 Working papers on Ligate's protocol-level research direction.
 
-## Active
+## Active: canonical protocol-primitive sequence
+
+The canonical sequence per the marketing-side umbrella tracker (ligate-marketing #48). Each paper specifies a runtime-level primitive of Ligate Chain in the order they ship.
 
 | Paper | Latest | Status | Topic |
 |---|---|---|---|
 | [PoUA, Proof of Useful Attestation](poua/) | v0.7.2 (2026-05-03) | Draft, external review (sending) | Consensus weighting primitive aligning validator influence with valid attestation work |
-| [Per-Schema Fee Markets](per-schema-fees/) | v0.1 (2026-05-02) | Outline | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
-| [Native Delegation](native-delegation/) | v0.1 (2026-05-03) | Outline | Hot-key / master-key separation as a runtime primitive; foundation for the Iris MCP relayer |
-| [Native DA Layer](native-da/) | v0.1 (2026-05-03) | Outline | Attestation-optimized data availability (post-Celestia track); per-schema indexed commitments, attestor-history queries, fee-market integration with PoUA τ_burn |
-| [Cross-Schema Composition](cross-schema-composition/) | v0.1 (2026-05-03) | Outline (deferred) | Typed attestation references with slashing-aware proof propagation; v2 protocol territory pending design-partner validation |
-| [Time-Locked Attestations](time-locked-attestations/) | v0.1 (2026-05-03) | Outline (deferred) | Commit-reveal as a runtime primitive; sealed-bid auctions, embargoed announcements, regulatory time-locks; v1.5 territory pending design-partner validation |
+| [Per-Schema Fee Markets](per-schema-fees/) | v0.1.1 (2026-05-04) | Outline + §4 substantive | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
+| [Cross-Schema Composition](cross-schema-composition/) | v0.1.1 (2026-05-04) | Outline + §3 + §4 substantive (deferred) | Typed attestation references with slashing-aware proof propagation; v2 protocol territory pending design-partner validation |
+| [Native Delegation](native-delegation/) | v0.1.1 (2026-05-04) | Outline + §5 substantive | Hot-key / master-key separation as a runtime primitive; foundation for the Iris MCP relayer |
+| [Time-Locked Attestations](time-locked-attestations/) | v0.1.1 (2026-05-04) | Outline + §4 substantive (deferred) | Commit-reveal as a runtime primitive; sealed-bid auctions, embargoed announcements, regulatory time-locks; v1.5 territory pending design-partner validation |
+| [Verifiable Content Provenance](verifiable-content-provenance/) | v0.0 (2026-05-05) | Planning | Detection, embedding, and watermarking for the Ligate Chain receipt layer; six-path detection model; depends on Atlas (ligate-marketing #96) |
+| [Themisra Licensing Schemas](themisra-licensing-schemas/) | v0.0 (2026-05-05) | Planning | Prompt licensing and content licensing as receipt-layer extensions under the Themisra umbrella |
 
 PoUA v0.7 is the empirical-validation milestone: every load-bearing claim has a published figure produced by the [reference simulator](../prototypes/poua-sim/), and cross-language test vectors at [`prototypes/poua-sim/test_vectors/`](../prototypes/poua-sim/test_vectors/) encode the analytical truths so the production implementation can re-validate the algebra in lockstep.
+
+## Other research tracks
+
+Papers outside the canonical protocol-primitive sequence.
+
+| Paper | Latest | Status | Topic |
+|---|---|---|---|
+| [Native DA Layer](native-da/) | v0.1.1 (2026-05-04) | Outline + §3 substantive | Attestation-optimized data availability (post-Celestia track); per-schema indexed commitments, attestor-history queries. Explicitly not advocacy for migration; documents the option. |
 
 ## Status definitions
 

--- a/papers/themisra-licensing-schemas/README.md
+++ b/papers/themisra-licensing-schemas/README.md
@@ -1,0 +1,70 @@
+# Themisra Licensing Schemas
+
+Two licensing schemas that ride on top of Proof of Prompt under the Themisra umbrella. Specifies prompt licensing and content licensing as receipt-layer extensions, with royalty routing, cross-schema composition, and sublicensing handled at the schema layer rather than the chain layer.
+
+## Latest
+
+- **Working paper**: not yet drafted. Folder reserved at v0.0 (planning).
+- **Version**: v0.0 (planning stage)
+- **Status**: **Planning.** No outline file yet. Authoring begins when Themisra umbrella positioning lands (ligate-marketing #95) and the per-schema fees paper reaches v0.2+ (the royalty-routing mechanics in §4 of this paper depend on the per-schema fee primitive).
+- **Date**: 2026-05-05
+
+## Why this paper exists
+
+Themisra is the umbrella product line for canonical AI-receipt schemas on Ligate Chain (per ligate-marketing #95: "Themisra is to AI receipts what Stripe is to payments"). Proof of Prompt is the first canonical schema; content provenance is the next; licensing is the layer above both.
+
+Two schemas covered here:
+
+- **`themisra.prompt-licensing/v1`** registers a prompt with creator attribution and royalty terms. Think of it as ASCAP for prompts: the prompt author gets a percentage of any commercial use that references the prompt.
+- **`themisra.content-licensing/v1`** registers an AI-generated artifact with creator attribution and licensing terms. The on-chain alternative to NFT-as-content patterns: the receipt layer holds the licensing logic, the artifact lives off-chain referenced by hash.
+
+Licensing is an **application-layer concern that belongs as a schema**, not a chain-layer token primitive. The receipt object stays minimal (claim, attestor, hash); the license is layered on as a separate attestation referencing the original receipt.
+
+## Planned outline
+
+When v0.1 authoring opens, the paper will follow this section structure. Each is `[**v0.1:** intent annotation]` only at v0.0.
+
+1. **Why licensing belongs as a schema, not as a chain-layer token primitive.** Keep the receipt object minimal: a Proof-of-Prompt receipt is a claim that "this prompt produced this output," not a license. License terms vary; the underlying claim does not. Layering license as a separate schema preserves the minimal-receipt invariant.
+2. **Schema design.** Fields, invariants, royalty terms, version-bumping rules. For prompt-licensing: prompt-id, creator-address, royalty-bps, license-type-enum, expiry. For content-licensing: artifact-hash, creator-address, royalty-bps, license-terms-uri, derivative-allowed-flag.
+3. **Cross-schema composition.** How prompt-licensing and content-licensing reference Proof-of-Prompt and content-provenance receipts. The cross-schema composition primitive (`papers/cross-schema-composition/`) is the foundation; this paper uses it.
+4. **Royalty distribution mechanics.** Each commercial use that references a licensed schema pays a fee split: protocol burn (PoUA τ_burn floor), attestor set, schema author (the prompt creator or content creator), and the per-schema-fee builder routing (per the per-schema-fees paper §4.4). Concrete split percentages and rationale.
+5. **Adversarial considerations.** License stripping (an attacker rewrites the artifact to remove the receipt reference; covered partly by content-provenance watermarking), derivative-work edge cases (when does a derivative trigger royalty? bright-line vs case-by-case), sublicensing (when can a licensee further license? bounded depth, scope-monotonicity).
+6. **Roadmap.** v1: prompt-licensing only. The simpler schema; the use case (creator earns from prompt reuse) is well-understood. v1+: content-licensing once content-provenance v0.1 paper has shipped and Atlas has receipt volume to verify against. v2+: cross-chain royalty routing once Hyperlane integration lands.
+
+## Discipline
+
+This paper adopts the v0.7-PoUA discipline from draft v0.1:
+
+- Every numerical claim links to a measurement, partner-supplied data, or simulation
+- Royalty-split recommendations are calibrated against real creator-economy data when available, marked as estimates otherwise
+- The cross-schema composition references are typed; the runtime type-check pipeline (cross-schema composition §4.4) enforces correctness
+
+## Dependencies
+
+- **`papers/cross-schema-composition/`** at v0.2+. The royalty schemas reference Proof-of-Prompt and content-provenance receipts; this requires the typed-reference primitive to be substantive in the supporting paper.
+- **`papers/per-schema-fees/`** at v0.2+. The royalty distribution mechanics in §4 layer on top of the per-schema fee market; the schema-routing fraction $\rho_\sigma$ from per-schema-fees §4.4 is the per-attestation primitive that this paper extends with author-and-derivative routing.
+- **`papers/verifiable-content-provenance/`** at v0.1+. License stripping is partially addressed by content-provenance watermarking (path 3); §5 of this paper references the cross-schema dependency on watermarking maturity.
+- **ligate-marketing #95**: Themisra umbrella positioning. The schemas defined in this paper sit under that umbrella.
+
+## Authoring trigger
+
+v0.1 authoring opens when:
+
+- Themisra umbrella positioning lands (ligate-marketing #95 acceptance items closed)
+- Per-schema fees paper at v0.2+ (royalty-routing mechanics need the fee market substantive)
+- Cross-schema composition at v0.2+ (typed references need to be substantive)
+- At least one prompt-marketplace partner conversation in flight (the use case has external pull)
+
+In the meantime, this scaffold reserves the directory and the schema names. New ideas land as comments on ligate-marketing #95 (the umbrella tracker).
+
+## Related
+
+- **ligate-marketing #95**: Themisra umbrella. This paper sits under that brand.
+- **`papers/cross-schema-composition/`**: typed-reference primitive that licensing schemas use.
+- **`papers/per-schema-fees/`**: per-attestation fee market that royalty distribution layers on.
+- **`papers/verifiable-content-provenance/`**: detection model for AI-generated artifacts. The licensing-schema content-licensing variant references content-provenance receipts as the input.
+- **PoUA paper**: τ_burn floor that royalty-split mechanics preserve (per Lemma 1 §5.5.3).
+
+## Stance
+
+Licensing is a Themisra schema, not a chain primitive. The chain is the receipt layer; the license is application logic on top. Keeping these separated is what makes the protocol minimal, the schemas composable, and the licensing economics tunable per use case without chain hard forks.

--- a/papers/verifiable-content-provenance/README.md
+++ b/papers/verifiable-content-provenance/README.md
@@ -1,0 +1,76 @@
+# Verifiable Content Provenance
+
+Detection, embedding, and watermarking for the Ligate Chain receipt layer. Specifies the six-path detection model, the canonical embedding spec across media types, the watermarking-primitive interface, and the honest coverage analysis per path and per adoption scenario.
+
+## Latest
+
+- **Working paper**: not yet drafted. Folder reserved at v0.0 (planning).
+- **Version**: v0.0 (planning stage)
+- **Status**: **Planning.** No outline file yet. Authoring begins when Atlas (the public verifier and registry product, ligate-marketing #96) reaches design-doc phase. The detection-side narrative needs Atlas's consumption surface to be specifiable before the paper can lock its embedding-spec recommendations.
+- **Date**: 2026-05-05
+
+## Why this paper exists
+
+Ligate Chain is the receipt layer for AI. Receipt creation alone is not enough: a receipt that nobody finds is a tree falling in an empty forest. Detection (catching when a registered prompt or generated artifact is actually used downstream) is the harder half of the system. Today the receipt-creation side is well-defined across Themisra, Mneme, and Iris; the detection side is currently underspecified across the stack.
+
+This paper lands the detection narrative honestly. Six paths catch usage at different points in the workflow. Combined, they cover the cooperative-and-discoverable majority. Adversarial cases (deliberate metadata stripping) are a tail risk addressed by watermarking, which is research-grade and pluggable rather than baked in.
+
+## Planned outline
+
+When v0.1 authoring opens, the paper will follow this section structure. Each is `[**v0.1:** intent annotation]` only at v0.0.
+
+1. **Problem statement.** Why receipt creation alone is insufficient. The cooperative-vs-adversarial spectrum: most usage is cooperative (the user wants attribution); a tail is adversarial (the user wants to strip provenance). Different defenses for different points on the spectrum.
+2. **The six-path detection model.**
+   - Cooperative reporting (legitimate user creates a derivative attestation referencing the original)
+   - Embedded references (artifacts carry receipt pointers in EXIF, ID3, document properties)
+   - Cryptographic watermarking (SynthID-style; survives compression and metadata stripping)
+   - API-layer integration (model providers like OpenAI and Anthropic integrate Themisra at the API call level)
+   - Iris agent-side attestation (auto-attestation by Iris-integrated agents)
+   - Public-web crawlers (Atlas-side scanning for embedded references)
+3. **Canonical embedding spec.** EXIF for images, ID3 for audio, document properties for PDFs / DOCX, Matroska tags for video, C2PA backward compatibility, tamper-resistance tradeoffs per format.
+4. **Watermarking primitives.** Survey of SynthID (Google DeepMind), Stable Signature (Meta), Stanford methods, and academic alternatives. Argument for a pluggable watermark-verifier interface inside Atlas rather than inventing our own scheme.
+5. **Coverage analysis.** Per path, per adoption scenario, honest percentages. Cooperative-and-discoverable majority (estimated 70-90% of real usage) caught by paths 1, 2, 4, 5. Adversarial tail caught by paths 3 and 6 with non-trivial probability.
+6. **Adversarial model.** What attackers can strip (metadata is removable; cryptographic watermarks are harder), where the receipt layer remains sound (the chain itself is untouched; it's the detection-side coverage that degrades), what assumptions remain when adversaries control specific paths.
+7. **Roadmap.** v0 devnet (paths 1 and 2 only), v1 mainnet (path 4 partner integrations), v2+ (paths 3 and 6 watermarking-and-crawler maturity). Honest about what each phase ships.
+
+## Discipline
+
+This paper adopts the v0.7-PoUA discipline from draft v0.1:
+
+- Every numerical claim links to a measurement, partner-supplied data, or simulation
+- Coverage estimates are estimated, not asserted; intervals reported when honest
+- The watermarking-primitive interface is specified abstractly; the chosen primitive is a pluggable choice, not a paper-bound commitment
+
+## Dependency
+
+This paper **depends on Atlas (ligate-marketing #96) shipping** before v0.1 authoring opens. Reasons:
+
+- The §3 canonical embedding spec needs the consumer (Atlas) to have a concrete read pipeline before the spec can lock format choices.
+- The §5 coverage analysis needs Atlas usage data to ground the estimated percentages.
+- The §6 adversarial model needs the public-API and crawler surfaces to be specifiable.
+
+Atlas is **not** in scope for the YC application or pre-seed pitch (per ligate-marketing #96). It enters the product story at v1 (months 8-14 from devnet), once Themisra has receipt volume worth verifying. This paper authoring follows that timeline.
+
+## Authoring trigger
+
+v0.1 authoring opens when:
+
+- Atlas product spec reaches design-doc phase (ligate-marketing #96 acceptance items move from `[ ]` to `[x]`)
+- At least two model-provider partner conversations are in flight (path 4 of the detection model has a real adoption signal)
+- A watermarking-primitive partner is identified (path 3 has a concrete first-choice integration)
+
+In the meantime, this scaffold reserves the directory and lays out the v0.1 structure. New ideas that belong in this paper land as comments on ligate-marketing #97 (the cross-surface tracker).
+
+## Related
+
+- **ligate-marketing #95**: Themisra umbrella positioning. The schemas under Themisra are what gets detected.
+- **ligate-marketing #96**: Atlas. The consumption-side surface that this paper's embedding spec is designed for.
+- **ligate-marketing #97**: detection tracker. Cross-surface coordination for the marketing-side work that runs alongside the paper.
+- **`papers/themisra-licensing-schemas/`**: licensing schemas in the Themisra family. References content-provenance receipts as inputs.
+- **`papers/cross-schema-composition/`**: typed attestation references; the content-provenance schema composes with Proof-of-Prompt receipts via this primitive.
+
+## Stance
+
+The realistic answer (cooperative-and-discoverable majority caught, adversarial tail leaks acceptable) is more credible than a "we catch everything" promise. This paper exists to articulate that realistic answer in formal language so external claims do not over-promise.
+
+Detection is **infrastructure plus partnerships plus research plus copy**. The paper covers the research portion. The infrastructure (Atlas), partnerships (model providers), and copy (marketing site, whitepaper) are tracked separately.


### PR DESCRIPTION
## Summary

Two new planned papers landing as v0.0 (planning stage) folders + README stubs, driven by positioning decisions in ligate-marketing repo:

- **\`papers/verifiable-content-provenance/\`**: detection, embedding, and watermarking for the Ligate Chain receipt layer. Specifies the six-path detection model. Drives ligate-marketing #97 (detection tracker) and depends on Atlas (ligate-marketing #96) shipping.
- **\`papers/themisra-licensing-schemas/\`**: prompt-licensing and content-licensing schemas under the Themisra umbrella (per ligate-marketing #95). Two schemas (\`themisra.prompt-licensing/v1\`, \`themisra.content-licensing/v1\`) with royalty routing and cross-schema composition.

Updates \`papers/README.md\` to:
- Reorder the Active table to match the canonical sequence per ligate-marketing #48 (PoUA → per-schema fees → cross-schema composition → native delegation → time-locked attestations → verifiable content provenance → Themisra licensing schemas)
- Add a separate \"Other research tracks\" section for Native DA Layer, which is explicitly not part of the canonical protocol-primitive sequence (it's the post-Celestia track)
- Update v0.1 → v0.1.1 on the four supplementary papers that gained substantive primary sections this week

## Source issues (in ligate-io/ligate-marketing)

- **#95**: Themisra umbrella positioning. Themisra-licensing-schemas paper sits under that brand.
- **#96**: Atlas (4th first-party flagship, public verifier and registry). Verifiable-content-provenance paper is the research artifact Atlas consumes.
- **#97**: Detection tracker (paper + GTM + embedding spec). Cross-surface tracker that references this repo as the home for the verifiable-content-provenance paper.
- **#48**: Protocol-primitives umbrella. Lists the canonical paper sequence; the two new entries slot at the end.

## Conventions applied

- Chain-first positioning: leads with \"Ligate Chain receipt layer\" / \"the receipt layer for AI\" / \"runtime-level primitive of Ligate Chain\". Does not lead with \"on Celestia\" anywhere.
- v0.0 status (planning stage), no \`.md\` paper file yet, README only.
- Authoring triggers documented for each paper (when v0.1 work opens).
- Cross-paper dependencies explicit (provenance → Atlas; licensing → cross-schema composition v0.2+, per-schema fees v0.2+, provenance v0.1+).
- One-line commit, no em dashes, no auto-push (approved by user).

## Verification

- Citation check: 46 citations ok across 26 paper files (was 24 paper files; +2 new READMEs)
- Zero em dashes in any new or modified file
- 26 paper files now resolve cleanly

## What this PR does NOT do

- Add a \`papers/atlas/\` folder. Atlas is product / engineering work in ligate-marketing #96; the supporting research lives in verifiable-content-provenance.
- Draft the actual papers (both at v0.0; v0.1 authoring opens when each paper's authoring trigger fires).
- Touch any existing paper's content. Only metadata in \`papers/README.md\`.

## Test plan

- [x] Citation check passes
- [x] Zero em dashes
- [x] Markdown renders cleanly
- [x] Canonical sequence matches ligate-marketing #48
- [x] Native DA Layer correctly placed in \"Other research tracks\" (per #48: not in the canonical sequence)
- [ ] Reviewer confirms scope and ordering before merge