### PR TITLE
Sim M7 phase 2a: per-validator delivery queue + proposer self-fix

### DIFF
--- a/prototypes/poua-sim/src/poua_sim/chain.py
+++ b/prototypes/poua-sim/src/poua_sim/chain.py
@@ -65,17 +65,55 @@ class Block:
     proposer : str
         Address of the proposing validator.
     voters : list[str]
-        Addresses of validators that committed (signed precommits on) this
-        block. Includes the proposer in standard BFT. M2 has every validator
-        vote on every block; M4 introduces selective abstention.
+        Addresses of validators that have committed on (precommit-signed)
+        this block. In M1-M6 this list is fully populated at block
+        creation. In M7 phase 2a (per-validator delivery queue), this
+        list grows over time as deliveries arrive at later slots; the
+        invariant ``len(voters) <= eventual_voter_count`` always holds.
     attestations : list[Attestation]
         Attestations included in this block.
+    eventual_voter_count : int
+        The fixed denominator used for the §4.3 voter-share term
+        ``g_vote = fee_share / n_voters``. This is set at block
+        creation time so late-arriving voters use the same denominator
+        as immediate voters; without this, the denominator would shrink
+        as more voters arrive and inflate later voters' g_vote credit.
+        Synchronous (no-scheduler) chains have
+        ``eventual_voter_count == len(voters)`` from the moment the
+        block is created.
     """
 
     slot: int
     proposer: str
     voters: list[str] = field(default_factory=list)
     attestations: list[Attestation] = field(default_factory=list)
+    eventual_voter_count: int = 0
+
+
+@dataclass(slots=True)
+class _PendingDelivery:
+    """A scheduled but not-yet-arrived block delivery for a validator.
+
+    Used by the M7 phase 2a per-validator delivery queue. Each pending
+    delivery records:
+
+    - ``block_idx``: index into ``Chain.blocks`` of the block being
+      delivered.
+    - ``delivery_slot``: the slot at which this validator becomes
+      voter-eligible for the block (per the network scheduler).
+    - ``n_voters_eventual``: the denominator used to compute this
+      voter's ``g_vote`` contribution. Fixed at block creation time
+      to preserve the §4.3 voter-share semantics under async delivery.
+
+    The chain holds a per-validator queue of these in
+    ``_pending_deliveries``. ``_drain_due_deliveries`` walks the queues
+    at each slot start and applies tallies for entries whose
+    ``delivery_slot`` has been reached.
+    """
+
+    block_idx: int
+    delivery_slot: int
+    n_voters_eventual: int
 
 
 def constant_attestations(
@@ -207,6 +245,11 @@ class Chain:
         }
         if len(self._validators_by_address) != len(self.validators):
             raise ValueError("validator addresses must be unique")
+        # M7 phase 2a: per-validator delivery queue. Empty for M1-M6 +
+        # #53 chains (no scheduler). Populated when a network scheduler
+        # is set and assigns a delivery slot strictly greater than the
+        # block's creation slot to one or more validators.
+        self._pending_deliveries: dict[str, list[_PendingDelivery]] = {}
 
     @property
     def total_weight(self) -> float:
@@ -221,19 +264,41 @@ class Chain:
     def advance_slot(self, rng: np.random.Generator) -> Block:
         """Advance one slot.
 
+        Phase 2a per-slot sequence:
+
+        0. Drain pending deliveries due at this slot. Each drained
+           entry adds a voter to its block's ``voters`` list and accrues
+           the corresponding ``g_vote`` contribution to the validator's
+           current epoch (which may differ from the block's creation
+           epoch under cross-epoch latency).
         1. Pick a proposer weighted by current ``w_v = s_v · r_v``.
-        2. Generate the block's attestations and voter set.
+        2. Generate the block's attestations.
         3. Apply the proposer's M6 ``behavior_policy`` transformation
            to the attestation list (no-op for HONEST).
         4. Apply equivocation slash if the proposer's policy is
            EQUIVOCATE.
-        5. Tally per-validator reputation contributions from this block.
-        6. Increment slot and, if a new epoch just ended, apply the §4.3
-           reputation update for every validator.
+        5. Determine the block's voter set:
+           - With no scheduler (M1-M6 + #53 baseline): every validator
+             in the voter pool votes immediately.
+           - With a scheduler (M7): consult ``scheduler.deliver`` for
+             per-validator delivery slots. Validators with delivery
+             slot ``<=`` current slot vote immediately; the rest are
+             enqueued in ``_pending_deliveries``. The proposer always
+             gets immediate self-delivery (corrects the phase 1
+             conservative simplification of treating the proposer like
+             any other delayed validator).
+        6. Append the block, tally proposer-side and immediate-voter
+           contributions with denominator ``eventual_voter_count``, and
+           run the §A.3 slashing check.
+        7. Increment slot and, if a new epoch just ended, apply the
+           §4.3 reputation update for every validator.
         """
+        # Step 0: drain pending deliveries due at this slot.
+        self._drain_due_deliveries(self.slot)
+
+        # Steps 1-4: proposer + attestations + policy + equivocation.
         proposer = select_proposer(self.validators, rng)
         attestations = self.attestation_generator(rng, self.slot, proposer.address)
-        # M6 phase 1+2+3: dispatch on proposer's behavior policy.
         attestations = apply_proposer_policy(
             proposer.behavior_policy,
             attestations,
@@ -248,39 +313,72 @@ class Chain:
                 self.params.r_max - self.params.r_min
             )
             self.slash(proposer.address, severity)
-        # M7 phase 1: voter pool is the full validator set when
-        # ``all_validators_vote`` is True (M2 default), otherwise only
-        # the proposer. The network scheduler (when set) further
-        # restricts the pool by excluding validators whose delivery slot
-        # exceeds the block's creation slot.
+
+        # Step 5: voter pool + scheduler dispatch.
         voters_pool = (
             self.validators if self.all_validators_vote else [proposer]
         )
         if self.network_scheduler is None:
-            voters = [v.address for v in voters_pool]
+            immediate_voters = [v.address for v in voters_pool]
+            late_voters_with_slots: list[tuple[str, int]] = []
+            eventual_voter_count = len(immediate_voters)
         else:
             delivery = self.network_scheduler.deliver(
                 block_slot=self.slot,
                 proposer_address=proposer.address,
                 recipients=voters_pool,
             )
-            voters = [
-                v.address
-                for v in voters_pool
-                if v.address in delivery and delivery[v.address] <= self.slot
+            # Proposer self-fix: the proposer always sees their own
+            # block at creation time. The scheduler's claim about
+            # proposer delivery is overridden because the proposer
+            # cannot be "delayed" relative to a block they just
+            # produced.
+            delivery[proposer.address] = self.slot
+            # Eventual voter set: all validators in the pool that the
+            # scheduler returned a delivery slot for. Validators absent
+            # from the mapping are treated as never-delivered (drops
+            # are phase 2b territory; in phase 2a all schedulers shipped
+            # always return a slot for every recipient).
+            eventual = [v for v in voters_pool if v.address in delivery]
+            eventual_voter_count = len(eventual)
+            immediate_voters = [
+                v.address for v in eventual if delivery[v.address] <= self.slot
             ]
+            late_voters_with_slots = [
+                (v.address, delivery[v.address])
+                for v in eventual
+                if delivery[v.address] > self.slot
+            ]
+
+        # Step 6: append block, schedule late deliveries, tally.
         block = Block(
             slot=self.slot,
             proposer=proposer.address,
-            voters=voters,
+            voters=list(immediate_voters),
             attestations=attestations,
+            eventual_voter_count=eventual_voter_count,
         )
+        block_idx = len(self.blocks)
         self.blocks.append(block)
-        self._tally_block(block)
+        # Schedule any late deliveries before tallying (so the queue
+        # state is consistent if tally code ever inspects it).
+        for voter_addr, delivery_slot in late_voters_with_slots:
+            self._pending_deliveries.setdefault(voter_addr, []).append(
+                _PendingDelivery(
+                    block_idx=block_idx,
+                    delivery_slot=delivery_slot,
+                    n_voters_eventual=eventual_voter_count,
+                )
+            )
+        # Tally proposer-side + immediate voters using the fixed
+        # ``eventual_voter_count`` denominator.
+        self._tally_block(block, immediate_voters, eventual_voter_count)
         # M6 follow-up Part A (#53): if §A.3 slashing is enabled, run
         # the detector against the proposer's rolling-window snapshot
         # and slash if fired. No-op when disabled (default).
         maybe_apply_a3_slash(self, proposer.address, self.a3_slash_config)
+
+        # Step 7: increment slot + epoch update.
         self.slot += 1
         if self.slot % self.params.epoch_length == 0:
             self._apply_epoch_reputation_update()
@@ -326,12 +424,17 @@ class Chain:
 
     # --- internal helpers ---------------------------------------------------
 
-    def _tally_block(self, block: Block) -> None:
-        """Accumulate per-validator ``g_prop`` and ``g_vote`` from this block.
+    def _tally_block(
+        self,
+        block: Block,
+        immediate_voters: list[str],
+        eventual_voter_count: int,
+    ) -> None:
+        """Accumulate per-validator ``g_prop`` and ``g_vote`` for the block.
 
         Per §4.3, ``G_v_prop`` sums fee-weighted valid attestations from
-        blocks ``v`` proposed; ``G_v_vote`` sums per-voter shares from blocks
-        ``v`` voted on but did NOT propose.
+        blocks ``v`` proposed; ``G_v_vote`` sums per-voter shares from
+        blocks ``v`` voted on but did NOT propose.
 
         §5.5 Layer 1 ("proposer-submitter address exclusion"): an
         attestation ``α`` contributes 0 to ``g_v(t)`` if
@@ -349,6 +452,28 @@ class Chain:
         ``cartel_marker`` attestations additionally accumulate into the
         ``epoch_g_*_from_cartel`` buckets used by the empirical Lemma 1
         validation in M4. This is instrumentation, not a protocol rule.
+
+        M7 phase 2a: this method tallies the proposer side (always
+        immediate at creation) and the immediate-voter side (validators
+        whose delivery slot is ``<=`` the block's creation slot). Late
+        voters are enqueued and tallied later by ``_drain_due_deliveries``,
+        each using the same ``eventual_voter_count`` denominator passed
+        in here. Without the fixed denominator, late voters would see a
+        smaller ``n_voters`` and inflate their per-vote share above the
+        synchronous-baseline value.
+
+        Parameters
+        ----------
+        block : Block
+            The block being tallied.
+        immediate_voters : list[str]
+            Addresses of validators whose delivery slot for this block
+            equals the block's creation slot (synchronous baseline:
+            every validator in the voter pool).
+        eventual_voter_count : int
+            The denominator used for ``g_vote`` contributions. Fixed at
+            block creation; equals ``len(immediate_voters)`` in the
+            no-scheduler case.
         """
         if not block.attestations:
             return
@@ -378,30 +503,93 @@ class Chain:
         proposer.epoch_g_prop += proposer_eligible_total
         proposer.epoch_g_prop_from_cartel += proposer_eligible_cartel
 
-        n_voters = len(block.voters)
-        if n_voters == 0:
+        if eventual_voter_count == 0:
             return
-        for voter_addr in block.voters:
-            if voter_addr == proposer_addr:
-                continue  # §4.3: proposer earns through G_prop, not G_vote, on own block
-            voter = self._validators_by_address[voter_addr]
-            voter_controlled = (
-                set(voter.controlled_addresses) if self.enable_layer_2 else set()
-            )
-            voter_eligible = 0.0
-            voter_eligible_cartel = 0.0
-            for a in block.attestations:
-                if not a.is_valid:
-                    continue
-                if a.submitter == voter_addr:
-                    continue  # Layer 1 on the voter side
-                if a.submitter in voter_controlled:
-                    continue  # Layer 2 on the voter side
-                voter_eligible += a.fee
-                if a.cartel_marker:
-                    voter_eligible_cartel += a.fee
-            voter.epoch_g_vote += voter_eligible / n_voters
-            voter.epoch_g_vote_from_cartel += voter_eligible_cartel / n_voters
+        for voter_addr in immediate_voters:
+            self._accumulate_voter_tally(block, voter_addr, eventual_voter_count)
+
+    def _accumulate_voter_tally(
+        self,
+        block: Block,
+        voter_addr: str,
+        n_voters_eventual: int,
+    ) -> None:
+        """Add a single voter's contribution to a block's ``g_vote`` tally.
+
+        Used for both immediate voters (called from ``_tally_block``)
+        and late-arriving voters (called from ``_drain_due_deliveries``
+        when their pending delivery's ``delivery_slot`` is reached).
+
+        The proposer is excluded per §4.3: proposers earn through
+        ``G_prop`` on their own block, not ``G_vote``.
+
+        The denominator ``n_voters_eventual`` is fixed at block creation
+        time. Under M7 phase 2a, late voters use the same denominator
+        as immediate voters so the per-block ``g_vote`` sum is bounded
+        by ``fee_eligible`` regardless of arrival timing.
+        """
+        if voter_addr == block.proposer:
+            return
+        if n_voters_eventual <= 0:
+            return
+        voter = self._validators_by_address[voter_addr]
+        voter_controlled = (
+            set(voter.controlled_addresses) if self.enable_layer_2 else set()
+        )
+        voter_eligible = 0.0
+        voter_eligible_cartel = 0.0
+        for a in block.attestations:
+            if not a.is_valid:
+                continue
+            if a.submitter == voter_addr:
+                continue  # Layer 1 on the voter side
+            if a.submitter in voter_controlled:
+                continue  # Layer 2 on the voter side
+            voter_eligible += a.fee
+            if a.cartel_marker:
+                voter_eligible_cartel += a.fee
+        voter.epoch_g_vote += voter_eligible / n_voters_eventual
+        voter.epoch_g_vote_from_cartel += voter_eligible_cartel / n_voters_eventual
+
+    def _drain_due_deliveries(self, current_slot: int) -> None:
+        """Apply pending deliveries whose ``delivery_slot <= current_slot``.
+
+        For each drained delivery, the late-arriving voter:
+
+        - is appended to the block's ``voters`` list (the ``voters``
+          list grows monotonically over time as deliveries arrive)
+        - has their ``g_vote`` contribution applied via
+          ``_accumulate_voter_tally`` using the block's
+          ``eventual_voter_count`` denominator
+
+        The contribution accrues to the validator's CURRENT epoch
+        (whichever epoch ``current_slot`` is in), which may differ
+        from the block's creation epoch under cross-epoch latency. This
+        matches the §4.3 update semantics: validators earn reputation
+        for work the chain can attribute to them in the epoch the work
+        becomes attributable, not retroactively into a past epoch whose
+        update has already been applied.
+        """
+        if not self._pending_deliveries:
+            return
+        # Iterate over a snapshot of keys to allow safe in-place removal
+        # of empty queues during the walk.
+        for voter_addr in list(self._pending_deliveries.keys()):
+            queue = self._pending_deliveries[voter_addr]
+            remaining: list[_PendingDelivery] = []
+            for pending in queue:
+                if pending.delivery_slot <= current_slot:
+                    block = self.blocks[pending.block_idx]
+                    self._accumulate_voter_tally(
+                        block, voter_addr, pending.n_voters_eventual
+                    )
+                    block.voters.append(voter_addr)
+                else:
+                    remaining.append(pending)
+            if remaining:
+                self._pending_deliveries[voter_addr] = remaining
+            else:
+                del self._pending_deliveries[voter_addr]
 
     def _apply_epoch_reputation_update(self) -> None:
         """Fire the §4.3 reputation update for every validator at epoch boundary."""

--- a/prototypes/poua-sim/tests/test_network.py
+++ b/prototypes/poua-sim/tests/test_network.py
@@ -33,6 +33,7 @@ from poua_sim.network import (
     NetworkScheduler,
     UniformLatencyScheduler,
 )
+from poua_sim.reputation import ReputationParams
 from poua_sim.validator import Validator
 
 
@@ -179,8 +180,13 @@ def test_chain_with_uniform_latency_zero_matches_synchronous() -> None:
     assert set(block.voters) == {"v0", "v1", "v2", "v3"}
 
 
-def test_chain_with_uniform_latency_delay_one_excludes_all_voters() -> None:
-    """In phase 1's same-slot model, ``delay >= 1`` empties the voter set."""
+def test_chain_with_uniform_latency_delay_one_voters_arrive_next_slot() -> None:
+    """Phase 2a: ``delay=1`` voters arrive at slot+1, not the creation slot.
+
+    At creation, only the proposer's self-delivery is immediate
+    (proposer-self-fix). After advancing one more slot, the queue
+    drains and the remaining voters are added to ``block.voters``.
+    """
     validators = [Validator(f"v{i}", stake=100.0) for i in range(4)]
     chain = Chain(
         validators=validators,
@@ -189,16 +195,16 @@ def test_chain_with_uniform_latency_delay_one_excludes_all_voters() -> None:
     )
     rng = np.random.default_rng(0)
     block = chain.advance_slot(rng)
-    assert block.voters == []
-    # Tally guard: empty voters means no g_vote contributions accrue.
-    for v in chain.validators:
-        if v.address == block.proposer:
-            continue
-        assert v.epoch_g_vote == 0.0
+    # Phase 2a: only the proposer is immediate (self-fix); others queued.
+    assert block.voters == [block.proposer]
+    assert block.eventual_voter_count == 4
+    # Advance one more slot; the queue drains and late voters arrive.
+    chain.advance_slot(rng)
+    assert set(block.voters) == {"v0", "v1", "v2", "v3"}
 
 
-def test_chain_with_adversarial_latency_cartel_only_votes() -> None:
-    """Honest validators delayed; cartel members are the only voters."""
+def test_chain_with_adversarial_latency_cartel_immediate_honest_arrive_late() -> None:
+    """Phase 2a: cartel votes immediately, honest validators arrive at slot+max_delay."""
     validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
     cartel = frozenset({"v0", "v1"})
     chain = Chain(
@@ -210,20 +216,25 @@ def test_chain_with_adversarial_latency_cartel_only_votes() -> None:
         ),
     )
     rng = np.random.default_rng(0)
-    # Run a few slots; every block should have exactly the cartel as voters.
-    for _ in range(10):
-        block = chain.advance_slot(rng)
-        assert set(block.voters) == {"v0", "v1"}
+    block = chain.advance_slot(rng)
+    # At creation: cartel members are immediate; proposer is also
+    # immediate (self-fix); honest non-proposers are queued.
+    expected_immediate = {"v0", "v1"} | {block.proposer}
+    assert set(block.voters) == expected_immediate
+    assert block.eventual_voter_count == 5
+    # After advancing one more slot, the queue drains and all voters
+    # are present on the block.
+    chain.advance_slot(rng)
+    assert set(block.voters) == {"v0", "v1", "v2", "v3", "v4"}
 
 
-def test_chain_with_adversarial_latency_proposer_outside_cartel_excluded() -> None:
-    """When honest validators (including the proposer) are delayed, the
-    proposer is also excluded from the voter set under phase 1's
-    conservative same-slot exclusion. Cartel members still vote.
+def test_chain_with_adversarial_latency_proposer_always_self_delivers() -> None:
+    """Phase 2a proposer-self-fix: an honest proposer sees their own
+    block at the creation slot, even when the adversarial scheduler
+    would otherwise treat the honest proposer as delayed.
 
-    This validates the design-doc note about phase 2 needing per-validator
-    local clocks for self-delivery; phase 1 treats the proposer like any
-    other delayed honest validator.
+    Replaces the phase 1 conservative simplification documented in the
+    M7 design doc §3.3.
     """
     # Stake-stack the proposer so we know who proposed.
     validators = [
@@ -243,17 +254,22 @@ def test_chain_with_adversarial_latency_proposer_outside_cartel_excluded() -> No
     rng = np.random.default_rng(0)
     block = chain.advance_slot(rng)
     assert block.proposer == "v0"
-    # Phase 1 conservative semantics: honest proposer is excluded.
-    # Only cartel votes.
-    assert set(block.voters) == {"v2"}
+    # Phase 2a: proposer-self-fix puts the honest proposer in the
+    # immediate voter set even though the adversarial scheduler would
+    # have delayed them.
+    assert set(block.voters) == {"v0", "v2"}
+    assert block.eventual_voter_count == 3
 
 
-def test_chain_with_adversarial_latency_unequal_voter_share() -> None:
-    """Over many slots with cartel-only voting, cartel members accumulate
-    ``epoch_g_vote`` while honest validators do not.
+def test_chain_with_adversarial_latency_voter_share_split() -> None:
+    """Phase 2a: cartel and honest both accumulate ``g_vote``, but the
+    cartel's contribution accrues at the creation slot while the
+    honest contribution is deferred by ``max_delay`` slots.
 
-    Validates that the latency restriction propagates through to
-    reputation accounting via the standard ``_tally_block`` path.
+    The denominator (``eventual_voter_count``) is the same for both,
+    so the per-vote share is identical; only the timing differs. The
+    honest deferral means the last block's honest votes are still
+    queued at the end of a finite test run.
     """
     validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
     cartel = frozenset({"v0", "v1"})
@@ -266,17 +282,33 @@ def test_chain_with_adversarial_latency_unequal_voter_share() -> None:
         ),
     )
     rng = np.random.default_rng(42)
-    for _ in range(20):
+    n_slots = 20
+    for _ in range(n_slots):
         chain.advance_slot(rng)
-    # Cartel members that did not propose the block accumulate g_vote.
-    # Honest members never accumulate any g_vote because they are
-    # excluded from every block's voter set.
+    # Per-block: 5 attestations × fee 1.0 = total 5.0; per-voter share
+    # = 5.0 / 5 = 1.0 for every non-proposer voter.
+    last_proposer = chain.blocks[-1].proposer
     for v in chain.validators:
+        proposed_count = sum(1 for b in chain.blocks if b.proposer == v.address)
+        not_proposed = n_slots - proposed_count
         if v.address in cartel:
-            continue  # cartel covered above
-        # Honest validators that proposed may have epoch_g_prop > 0 if
-        # they were the proposer at that slot, but g_vote must be zero.
-        assert v.epoch_g_vote == 0.0
+            # Cartel: all non-proposed blocks tallied immediately.
+            expected = float(not_proposed)
+        else:
+            # Honest: deferred by max_delay=1 slot. The last block's
+            # delivery slot is n_slots, which is never drained inside
+            # this test (we only advance to n_slots-1). So honest
+            # validators are missing the last block's vote, EXCEPT the
+            # honest validator who proposed it (no g_vote was due).
+            if v.address == last_proposer:
+                expected = float(not_proposed)
+            else:
+                expected = float(not_proposed - 1)
+        assert v.epoch_g_vote == expected, (
+            f"validator {v.address}: expected g_vote={expected}, "
+            f"got {v.epoch_g_vote}; proposed_count={proposed_count}, "
+            f"last_proposer={last_proposer}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -310,3 +342,201 @@ def test_chain_scheduler_compatible_with_layer_2() -> None:
     # Layer 2 still active (no controlled-addr submitters in this gen,
     # so the assertion is just non-crashing behavior; the dedicated
     # Layer 2 tests in test_layer_2.py cover the rejection semantics).
+
+
+# ---------------------------------------------------------------------------
+# Phase 2a: per-validator delivery queue semantics
+# ---------------------------------------------------------------------------
+
+
+def test_phase2a_eventual_voter_count_fixed_at_creation() -> None:
+    """Late voters use the same denominator as immediate voters.
+
+    Without this invariant, late voters would see a smaller
+    ``len(block.voters)`` and inflate their per-vote share above the
+    synchronous-baseline value. The fixed denominator keeps the per-block
+    ``g_vote`` sum bounded by ``fee_eligible`` regardless of arrival order.
+    """
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(4)]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5, fee=1.0),
+        network_scheduler=UniformLatencyScheduler(delay=2),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)
+    proposer = block.proposer
+    # Block created at slot 0; eventual voter count locked at 4.
+    assert block.eventual_voter_count == 4
+    # Advance two slots to drain the late-arriving voters.
+    chain.advance_slot(rng)
+    chain.advance_slot(rng)
+    # Every non-proposer validator should have received the SAME
+    # share: 5.0 fee total / 4 voters = 1.25 g_vote contribution
+    # from this block. No arrival-order inflation.
+    for v in chain.validators:
+        if v.address == proposer:
+            continue
+        # The validator has g_vote contributions from blocks at slots
+        # 0 (delivered slot 2) and possibly 1 (delivered slot 3, not
+        # yet drained). At least slot-0 block is fully drained.
+        # Lower-bound check: each non-proposer accumulated at least
+        # the slot-0 block's share.
+        assert v.epoch_g_vote >= 5.0 / 4
+
+
+def test_phase2a_late_voter_arrives_at_delivery_slot() -> None:
+    """A delayed voter is added to ``block.voters`` exactly at the slot
+    matching their scheduler-determined delivery slot, not before."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=UniformLatencyScheduler(delay=3),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)  # slot 0
+    proposer = block.proposer
+    other_voters = {v.address for v in validators if v.address != proposer}
+    # Slot 0: only proposer immediate (self-fix)
+    assert set(block.voters) == {proposer}
+    # Slot 1: not yet delivered (delivery_slot=3)
+    chain.advance_slot(rng)
+    assert set(block.voters) == {proposer}
+    # Slot 2: still not yet delivered
+    chain.advance_slot(rng)
+    assert set(block.voters) == {proposer}
+    # Slot 3: drain. Late voters arrive.
+    chain.advance_slot(rng)
+    assert set(block.voters) == {proposer} | other_voters
+
+
+def test_phase2a_no_scheduler_keeps_queue_empty() -> None:
+    """Backward-compat: chains without a scheduler never enqueue any
+    pending deliveries.
+
+    Guards against the queue infrastructure leaking into the M1-M6
+    synchronous code path.
+    """
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(4)]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(50):
+        chain.advance_slot(rng)
+    # Internal state check: no pending deliveries ever recorded.
+    assert chain._pending_deliveries == {}
+    # Every block has eventual_voter_count == len(voters) == 4.
+    for block in chain.blocks:
+        assert len(block.voters) == 4
+        assert block.eventual_voter_count == 4
+
+
+def test_phase2a_cross_epoch_delivery_accrues_to_delivery_epoch() -> None:
+    """A vote whose delivery slot crosses an epoch boundary accrues to
+    the validator's epoch AT DELIVERY time, not retroactively to the
+    block-creation epoch.
+
+    The §4.3 update fires at epoch boundaries; per-epoch counters reset
+    after the update. A late vote arriving after the boundary cannot
+    accrue to the now-reset counters; it accrues to the new epoch.
+    """
+    # 4 slots per epoch so we can cross a boundary in a few slots.
+    params = ReputationParams(epoch_length=4)
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    chain = Chain(
+        validators=validators,
+        params=params,
+        attestation_generator=constant_attestations(n_per_block=5, fee=1.0),
+        network_scheduler=UniformLatencyScheduler(delay=4),  # crosses boundary
+    )
+    rng = np.random.default_rng(0)
+    # Slot 0: block created with delivery_slot=4 for non-proposer voters.
+    block = chain.advance_slot(rng)
+    proposer = block.proposer
+    # Slots 1, 2, 3: nothing drains.
+    for _ in range(3):
+        chain.advance_slot(rng)
+    # At end of slot 3 advance, slot becomes 4 and the §4.3 update
+    # fires (epoch 0 → epoch 1). Per-epoch counters reset.
+    assert chain.slot == 4
+    assert chain.epoch == 1
+    # Pre-drain check: the proposer's epoch_g_prop reset to 0 at the
+    # boundary (the proposer's tally was applied before the boundary
+    # for slot 0, then reset at slot 4 boundary fire).
+    proposer_validator = chain._validators_by_address[proposer]
+    assert proposer_validator.epoch_g_prop == 0.0
+    # Slot 4: now the late deliveries drain at start. Voter g_vote
+    # accrues to the NEW epoch (epoch 1).
+    chain.advance_slot(rng)
+    # Non-proposer validators should have epoch_g_vote > 0 in the new
+    # epoch from the slot-0 block's delayed delivery.
+    for v in chain.validators:
+        if v.address == proposer:
+            continue
+        # They received the slot-0 block's delivery at slot 4, which
+        # is in epoch 1. Cumulative g_vote may include other blocks
+        # from epoch 1's slots, so use a lower bound: at minimum the
+        # slot-0 block's contribution (5.0 / 3 = ~1.667).
+        assert v.epoch_g_vote >= 5.0 / 3 - 1e-9
+
+
+def test_phase2a_proposer_self_fix_overrides_scheduler() -> None:
+    """The proposer-self-fix forces immediate delivery for the proposer
+    even if the scheduler returns a delayed slot for them.
+
+    This corrects the phase 1 conservative simplification where an
+    honest proposer was treated as delayed by AdversarialLatencyScheduler.
+    """
+    # Scheduler that delays everyone (including the proposer in its
+    # naive output).
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=UniformLatencyScheduler(delay=10),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)
+    # Despite delay=10 applying to everyone, the proposer is in the
+    # immediate voter set due to self-fix.
+    assert block.proposer in block.voters
+
+
+def test_phase2a_pending_deliveries_drain_in_order_across_slots() -> None:
+    """Pending deliveries scheduled for different slots drain at their
+    respective slots without leaking past their delivery time."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=UniformLatencyScheduler(delay=2),
+    )
+    rng = np.random.default_rng(0)
+    # Block 0 created at slot 0; non-proposer voters scheduled for slot 2.
+    block_0 = chain.advance_slot(rng)
+    # Block 1 created at slot 1; non-proposer voters scheduled for slot 3.
+    block_1 = chain.advance_slot(rng)
+    # At end of slot 1, queue should hold late deliveries for both blocks.
+    pending_count_after_slot_1 = sum(
+        len(q) for q in chain._pending_deliveries.values()
+    )
+    # 2 non-proposer voters per block × 2 blocks = 4 pending entries.
+    assert pending_count_after_slot_1 == 4
+    # Slot 2: drain block 0's deliveries (delivery_slot=2 <= 2). Block
+    # 1's deliveries (delivery_slot=3) remain queued.
+    chain.advance_slot(rng)
+    pending_count_after_slot_2 = sum(
+        len(q) for q in chain._pending_deliveries.values()
+    )
+    # Block 0 fully delivered: 2 entries removed.
+    # Block 2 (just-created) adds 2 entries (delivery slot 4).
+    # Block 1's 2 entries still pending.
+    # Net: 2 (block 1) + 2 (block 2) = 4
+    assert pending_count_after_slot_2 == 4
+    # Verify block_0 is now fully delivered.
+    assert len(block_0.voters) == 3
+    # Block 1 still missing late voters.
+    assert len(block_1.voters) < 3


### PR DESCRIPTION
## Summary

M7 phase 2a: the **architectural inflection** that lets blocks be voted on at later slots than their creation slot. This is the multi-day infrastructure the M7 design doc flagged as the long pole; phase 2b (PartitionScheduler), phase 3 (EclipseScheduler), and phase 4 (scale benchmarks) build on top of this without further chain-level refactoring.

Tracks #31 (M7 milestone). Phase 1 shipped in PR #75.

## What ships

### `Block.eventual_voter_count: int`

New field, set at block creation. Locks the `g_vote` denominator so late-arriving voters use the same per-vote share as immediate voters. Without this, late voters would see a smaller `len(block.voters)` and inflate their share above the synchronous-baseline value.

### `_PendingDelivery` private dataclass + per-validator queue

```python
@dataclass(slots=True)
class _PendingDelivery:
    block_idx: int
    delivery_slot: int
    n_voters_eventual: int

class Chain:
    ...
    _pending_deliveries: dict[str, list[_PendingDelivery]] = {}  # init in __post_init__
```

### `_drain_due_deliveries(current_slot)` method

Walks every validator's queue at the start of each `advance_slot`. Drains entries with `delivery_slot <= current_slot`: appends the validator to the block's `voters` list and accrues their `g_vote` contribution to the validator's CURRENT epoch (which may differ from the block's creation epoch under cross-epoch latency).

### `_accumulate_voter_tally(block, voter_addr, n_voters_eventual)` helper

Per-voter tally extracted from the old `_tally_block`. Used by both `_tally_block` (for immediate voters) and `_drain_due_deliveries` (for late voters). Keeps Layer 1 + Layer 2 (#53) rejection logic in one place.

### Refactored `advance_slot`

```
0. drain pending deliveries due at current slot
1. select proposer
2. generate attestations
3. apply behavior policy
4. equivocation slash check
5. consult scheduler → split into immediate + late voters
   - proposer-self-fix: proposer always gets delivery_slot = current_slot
   - eventual_voter_count = total voters with concrete delivery slots
6. append block, schedule late deliveries, tally proposer + immediate
7. A3 slash check (existing)
8. increment slot + epoch update (existing)
```

### Proposer-self-fix

The phase 1 conservative simplification ("proposer treated like any other delayed validator") is corrected: the proposer always sees their own block at the creation slot, regardless of what the scheduler claims. Documented in the M7 design doc §3.3 as the right phase 2 behavior.

## Test changes

### Phase 1 tests updated for phase 2a semantics (4 tests)

| Test | Phase 1 expectation | Phase 2a expectation |
|---|---|---|
| `..._delay_one_excludes_all_voters` (renamed `..._voters_arrive_next_slot`) | empty voter set | proposer immediate, others arrive at slot+1 |
| `..._cartel_only_votes` (renamed `..._cartel_immediate_honest_arrive_late`) | cartel-only voter set forever | cartel immediate, honest catch up at slot+max_delay |
| `..._proposer_outside_cartel_excluded` (renamed `..._proposer_always_self_delivers`) | proposer in voter set only if cartel | proposer always self-delivers |
| `..._unequal_voter_share` (renamed `..._voter_share_split`) | honest g_vote == 0 | honest g_vote > 0 with deferred timing; analytical per-validator assertion |

### Phase 2a tests added (6 new)

- `test_phase2a_eventual_voter_count_fixed_at_creation`: late voters use the same denominator
- `test_phase2a_late_voter_arrives_at_delivery_slot`: voter appears in `block.voters` exactly at their delivery slot
- `test_phase2a_no_scheduler_keeps_queue_empty`: backward-compat regression guard for M1-M6 chains
- `test_phase2a_cross_epoch_delivery_accrues_to_delivery_epoch`: vote crossing epoch boundary accrues to the new epoch
- `test_phase2a_proposer_self_fix_overrides_scheduler`: even with `delay=10`, proposer is in immediate voter set
- `test_phase2a_pending_deliveries_drain_in_order_across_slots`: queue state across multiple slots

## Test plan

- [x] `python -m pytest -q` from `prototypes/poua-sim/`: **238 passing** (was 232 at end of phase 1; +6 new phase 2a, 4 phase 1 updated, zero unrelated regressions)
- [x] Backward compat verified: `network_scheduler=None` chains keep `_pending_deliveries == {}` over 50 slots
- [x] Cross-epoch semantics verified: vote arriving after epoch boundary accrues to new epoch (not retroactively)
- [x] Denominator invariant verified: per-vote share is `fee_eligible / eventual_voter_count` regardless of arrival timing
- [x] CI citations check expected to pass (no paper-side path citations affected)

## What this PR does NOT do

- **PartitionScheduler**: phase 2b. Drops + heal mechanism, plus liveness-after-heal integration tests. Builds directly on this PR's queue infrastructure.
- **EclipseScheduler**: phase 3. Target-validator view restricted to cartel-proposed blocks. Builds on phases 2a + 2b.
- **Scale benchmarks**: phase 4. Sweep validator counts; report wall-clock + memory.
- **v0.8 paper figures**: will land alongside their respective phases.

## Why this is the architectural inflection

Phases 2b, 3, and 4 are all "what does the scheduler return?" questions. With the queue infrastructure in place, those phases each ship a single new scheduler class plus their tests. The hard part — making the chain support deferred delivery without breaking the §4.3 voter-share semantics — is solved here.
