### PR TITLE
Sim M7 phase 2b: PartitionScheduler with drop semantics

### DIFF
--- a/prototypes/poua-sim/src/poua_sim/__init__.py
+++ b/prototypes/poua-sim/src/poua_sim/__init__.py
@@ -17,9 +17,10 @@ Layout (M4):
                          dispatch helpers (HONEST, EQUIVOCATE,
                          FREE_RIDE_VIA_VOTE_ONLY)
     poua_sim.adversary   Capital adversary (M3) + compound adversary (M4)
-    poua_sim.network     M7 phase 1: NetworkScheduler protocol +
+    poua_sim.network     M7 phases 1+2b: NetworkScheduler protocol +
                          UniformLatencyScheduler +
-                         AdversarialLatencyScheduler
+                         AdversarialLatencyScheduler +
+                         PartitionScheduler
 
 Future modules (M5, milestones tracked in
 https://github.com/ligate-io/ligate-research/issues/3):
@@ -71,6 +72,7 @@ from poua_sim.metrics import (
 from poua_sim.network import (
     AdversarialLatencyScheduler,
     NetworkScheduler,
+    PartitionScheduler,
     UniformLatencyScheduler,
 )
 from poua_sim.proposer import select_proposer
@@ -112,6 +114,7 @@ __all__ = [
     "PHASE1_POLICIES",
     "PHASE2_POLICIES",
     "PHASE3_POLICIES",
+    "PartitionScheduler",
     "RebaseConfig",
     "RebaseTelemetry",
     "ReputationParams",

--- a/prototypes/poua-sim/src/poua_sim/network.py
+++ b/prototypes/poua-sim/src/poua_sim/network.py
@@ -3,25 +3,22 @@
 A ``NetworkScheduler`` decides which validators receive which blocks at
 which slot offsets. The chain consults the scheduler at vote-construction
 time: validators whose delivery slot exceeds the block's creation slot
-are excluded from that block's voter set.
+are excluded from that block's voter set; validators absent from the
+returned mapping are treated as never-delivered (drops).
 
-This is M7 phase 1 (latency only). Per the M7 design doc at
-``prototypes/poua-sim/docs/m7-design.md``:
+Per the M7 design doc at ``prototypes/poua-sim/docs/m7-design.md``:
 
-- Phase 1 (this module): ``UniformLatencyScheduler`` +
-  ``AdversarialLatencyScheduler``. Validates the architecture without
-  per-validator local-clock complexity.
-- Phase 2: adds ``PartitionScheduler`` and per-validator local clock so
-  delayed blocks can still be voted on at later slots.
+- **Phase 1**: ``UniformLatencyScheduler`` + ``AdversarialLatencyScheduler``.
+  Validates the architecture without per-validator local-clock complexity.
+- **Phase 2a**: per-validator delivery queue in ``Chain`` so delayed
+  blocks can be voted on at later slots; the ``g_vote`` denominator
+  is fixed at block creation to preserve §4.3 voter-share semantics.
+- **Phase 2b** (this module's latest addition): ``PartitionScheduler``
+  with drop semantics. Validators in the isolated group do not receive
+  blocks during the partition window.
 - Phase 3: adds ``EclipseScheduler`` (target-validator view restricted
   to cartel-proposed blocks).
 - Phase 4: scale benchmarks.
-
-Phase 1 model is intentionally coarse: a validator whose delivery slot
-exceeds the block's creation slot is simply excluded from that block's
-voter set in the same slot. There is no buffering of "pending votes"
-across slots; that is phase 2 territory once per-validator local clocks
-are introduced.
 
 Default behavior preserved: when ``Chain.network_scheduler is None``,
 the chain is fully synchronous (M1-M6 + #53 baseline). Setting a
@@ -173,3 +170,94 @@ class AdversarialLatencyScheduler:
             )
             for v in recipients
         }
+
+
+@dataclass(slots=True, frozen=True)
+class PartitionScheduler:
+    """Drop cross-group delivery during a finite partition window.
+
+    During ``[partition_start_slot, partition_end_slot)``, validators in
+    ``isolated_group`` do not receive blocks (their address is absent
+    from the returned delivery mapping, which the chain treats as
+    never-delivered). Outside the window, all validators receive blocks
+    immediately.
+
+    This models a network adversary that isolates a group of validators
+    from the chain's canonical view for a finite duration. After the
+    window ends, isolated validators resume normal delivery for new
+    blocks; they do NOT receive the blocks they missed during the window
+    (replay / catch-up is out of scope for phase 2b — modeling fork
+    reconciliation requires multi-chain bookkeeping that this simulator
+    does not provide).
+
+    Phase 2b interpretation: the chain models ONE perspective (the
+    canonical chain seen by non-isolated validators). Cartel-proposed
+    blocks during the window still happen and are visible to the
+    cartel members; isolated validators just don't see them. Reputation
+    accounting during the window uses the reduced ``eventual_voter_count``
+    (drops shrink the denominator), so the smaller voting group's per-vote
+    share is correspondingly larger. This is the §4.3 semantic carried
+    through honestly: validators who actually delivered a block earn
+    proportionally more on that block than they would in a healthy
+    quorum.
+
+    The proposer-self-fix in ``Chain.advance_slot`` ensures the proposer
+    always sees their own block at creation, even if the proposer is
+    in ``isolated_group`` and the partition window is active. This
+    matches reality: a proposer cannot be "partitioned" from their own
+    just-produced block.
+
+    Parameters
+    ----------
+    isolated_group : frozenset[str]
+        Addresses of validators isolated during the partition window.
+        Empty set is allowed (degenerates to a no-op scheduler).
+    partition_start_slot : int
+        First slot of the partition window (inclusive).
+    partition_end_slot : int
+        First slot AFTER the partition window (exclusive). Must be
+        ``>= partition_start_slot``. Equality means an empty (zero-length)
+        window, which is a no-op.
+
+    Raises
+    ------
+    ValueError
+        If ``partition_end_slot < partition_start_slot``.
+
+    Notes
+    -----
+    For testing partition liveness, set
+    ``isolated_group=frozenset({"v0", "v1"})``,
+    ``partition_start_slot=10``, ``partition_end_slot=20``. Validators
+    v0 and v1 do not receive blocks during slots 10-19 and resume
+    normal delivery at slot 20.
+    """
+
+    isolated_group: frozenset[str] = field(default_factory=frozenset)
+    partition_start_slot: int = 0
+    partition_end_slot: int = 0
+
+    def __post_init__(self) -> None:
+        if self.partition_end_slot < self.partition_start_slot:
+            raise ValueError(
+                f"partition_end_slot ({self.partition_end_slot}) must be "
+                f">= partition_start_slot ({self.partition_start_slot})"
+            )
+
+    def deliver(
+        self,
+        block_slot: int,
+        proposer_address: str,
+        recipients: list[Validator],
+    ) -> dict[str, int]:
+        in_partition = (
+            self.partition_start_slot <= block_slot < self.partition_end_slot
+        )
+        result: dict[str, int] = {}
+        for v in recipients:
+            if in_partition and v.address in self.isolated_group:
+                # Drop: omit from mapping. Chain treats absence as
+                # never-delivered.
+                continue
+            result[v.address] = block_slot
+        return result

--- a/prototypes/poua-sim/tests/test_network.py
+++ b/prototypes/poua-sim/tests/test_network.py
@@ -31,6 +31,7 @@ from poua_sim.chain import Chain, constant_attestations
 from poua_sim.network import (
     AdversarialLatencyScheduler,
     NetworkScheduler,
+    PartitionScheduler,
     UniformLatencyScheduler,
 )
 from poua_sim.reputation import ReputationParams
@@ -540,3 +541,298 @@ def test_phase2a_pending_deliveries_drain_in_order_across_slots() -> None:
     assert len(block_0.voters) == 3
     # Block 1 still missing late voters.
     assert len(block_1.voters) < 3
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b: PartitionScheduler unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_partition_scheduler_satisfies_protocol() -> None:
+    scheduler = PartitionScheduler()
+    assert isinstance(scheduler, NetworkScheduler)
+
+
+def test_partition_scheduler_negative_window_raises() -> None:
+    with pytest.raises(ValueError, match=">= partition_start_slot"):
+        PartitionScheduler(partition_start_slot=10, partition_end_slot=5)
+
+
+def test_partition_scheduler_drops_isolated_during_window() -> None:
+    """Isolated validators are absent from the delivery mapping during
+    the partition window."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
+    scheduler = PartitionScheduler(
+        isolated_group=frozenset({"v0", "v1"}),
+        partition_start_slot=10,
+        partition_end_slot=20,
+    )
+    delivery = scheduler.deliver(
+        block_slot=15,  # inside window
+        proposer_address="v2",
+        recipients=validators,
+    )
+    # Isolated validators are dropped (not in mapping).
+    assert "v0" not in delivery
+    assert "v1" not in delivery
+    # Non-isolated get immediate delivery.
+    assert delivery["v2"] == 15
+    assert delivery["v3"] == 15
+    assert delivery["v4"] == 15
+
+
+def test_partition_scheduler_no_drops_before_window() -> None:
+    """Before partition_start_slot, no drops; everyone delivers."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = PartitionScheduler(
+        isolated_group=frozenset({"v0"}),
+        partition_start_slot=10,
+        partition_end_slot=20,
+    )
+    delivery = scheduler.deliver(
+        block_slot=5,  # before window
+        proposer_address="v1",
+        recipients=validators,
+    )
+    assert set(delivery.keys()) == {"v0", "v1", "v2"}
+
+
+def test_partition_scheduler_no_drops_at_or_after_end_slot() -> None:
+    """At and after partition_end_slot (exclusive end), no drops."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = PartitionScheduler(
+        isolated_group=frozenset({"v0"}),
+        partition_start_slot=10,
+        partition_end_slot=20,
+    )
+    # Slot 20 is exactly the end (exclusive); should NOT drop.
+    delivery_at_end = scheduler.deliver(
+        block_slot=20, proposer_address="v1", recipients=validators
+    )
+    assert set(delivery_at_end.keys()) == {"v0", "v1", "v2"}
+    # Slot 21 is after the end; should NOT drop.
+    delivery_after = scheduler.deliver(
+        block_slot=21, proposer_address="v1", recipients=validators
+    )
+    assert set(delivery_after.keys()) == {"v0", "v1", "v2"}
+
+
+def test_partition_scheduler_empty_isolated_group_is_noop() -> None:
+    """Empty ``isolated_group`` produces full delivery regardless of window."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = PartitionScheduler(
+        isolated_group=frozenset(),
+        partition_start_slot=0,
+        partition_end_slot=100,
+    )
+    delivery = scheduler.deliver(
+        block_slot=50, proposer_address="v0", recipients=validators
+    )
+    assert set(delivery.keys()) == {"v0", "v1", "v2"}
+
+
+def test_partition_scheduler_equal_start_and_end_is_noop() -> None:
+    """Zero-length window: ``partition_start_slot == partition_end_slot``
+    means no slot is in the window (start <= s < end is empty)."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = PartitionScheduler(
+        isolated_group=frozenset({"v0", "v1"}),
+        partition_start_slot=10,
+        partition_end_slot=10,
+    )
+    delivery = scheduler.deliver(
+        block_slot=10, proposer_address="v2", recipients=validators
+    )
+    # No slot is "in" the window; everyone delivers.
+    assert set(delivery.keys()) == {"v0", "v1", "v2"}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b: PartitionScheduler chain-integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_partition_chain_isolated_no_g_vote_during_window() -> None:
+    """During the partition window, isolated validators do not accumulate
+    g_vote on blocks proposed by non-isolated validators (drops mean they
+    are absent from eventual_voter_count and from the per-block delivery).
+    """
+    # 5 validators; v0 + v1 isolated. Force v2 to be the proposer by
+    # stake-stacking so the test is deterministic.
+    validators = [
+        Validator("v0", stake=1.0),
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=10000.0),  # heavy proposer
+        Validator("v3", stake=1.0),
+        Validator("v4", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0", "v1"}),
+            partition_start_slot=0,
+            partition_end_slot=10,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(10):
+        chain.advance_slot(rng)
+    # Inside the window, v0 and v1 receive nothing; their g_vote stays 0.
+    v0 = chain._validators_by_address["v0"]
+    v1 = chain._validators_by_address["v1"]
+    assert v0.epoch_g_vote == 0.0
+    assert v1.epoch_g_vote == 0.0
+    # Non-isolated voters DO accumulate g_vote.
+    v3 = chain._validators_by_address["v3"]
+    assert v3.epoch_g_vote > 0.0
+
+
+def test_partition_chain_eventual_voter_count_reflects_drops() -> None:
+    """The block's ``eventual_voter_count`` excludes dropped validators,
+    making the per-vote share larger for surviving voters."""
+    validators = [
+        Validator("v0", stake=1.0),
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=10000.0),  # heavy proposer
+        Validator("v3", stake=1.0),
+        Validator("v4", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5, fee=1.0),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0", "v1"}),
+            partition_start_slot=0,
+            partition_end_slot=5,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)
+    # 3 of 5 validators in eventual voter set (v2, v3, v4).
+    assert block.eventual_voter_count == 3
+    # Per-vote share = 5.0 fee / 3 voters = ~1.667 (was 5.0/5 = 1.0
+    # without partition).
+    v3 = chain._validators_by_address["v3"]
+    assert v3.epoch_g_vote == 5.0 / 3
+
+
+def test_partition_chain_heals_after_window() -> None:
+    """After the partition window ends, isolated validators resume
+    normal delivery for new blocks."""
+    validators = [
+        Validator("v0", stake=1.0),
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=10000.0),  # heavy proposer
+        Validator("v3", stake=1.0),
+        Validator("v4", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0", "v1"}),
+            partition_start_slot=0,
+            partition_end_slot=5,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    # Slots 0-4: window active; v0/v1 dropped.
+    for _ in range(5):
+        chain.advance_slot(rng)
+    # Slot 5: window ended; produce a block. v0 and v1 should now
+    # deliver immediately (no drops).
+    block_after_heal = chain.advance_slot(rng)
+    # Heaviest proposer is v2; v0 and v1 should be in voter set.
+    assert "v0" in block_after_heal.voters
+    assert "v1" in block_after_heal.voters
+    assert block_after_heal.eventual_voter_count == 5
+
+
+def test_partition_chain_liveness_during_window() -> None:
+    """The chain continues to advance during the partition window;
+    block production does not halt because some validators are isolated.
+    """
+    validators = [
+        Validator("v0", stake=1.0),
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=10000.0),
+        Validator("v3", stake=1.0),
+        Validator("v4", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0", "v1"}),
+            partition_start_slot=0,
+            partition_end_slot=20,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        chain.advance_slot(rng)
+    # Chain produced 20 blocks; slot advanced to 20.
+    assert chain.slot == 20
+    assert len(chain.blocks) == 20
+
+
+def test_partition_chain_isolated_proposer_self_fix() -> None:
+    """If an isolated-group validator happens to be the proposer during
+    the partition window, the proposer-self-fix puts them in their own
+    block's voter set (a proposer always sees their own just-produced
+    block). This is the canonical-chain perspective only; modeling the
+    cartel's separate fork is out of scope."""
+    # Stake-stack v0 (in isolated group) so it is the proposer.
+    validators = [
+        Validator("v0", stake=10000.0),  # isolated proposer
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=1.0),
+        Validator("v3", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0"}),
+            partition_start_slot=0,
+            partition_end_slot=5,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)
+    assert block.proposer == "v0"
+    # Proposer-self-fix: v0 IS in the voter set despite being isolated.
+    assert "v0" in block.voters
+    # Other validators (non-isolated) ALSO deliver during partition
+    # because they're not in isolated_group. So they appear in voters too.
+    assert "v1" in block.voters
+    # eventual_voter_count = 4 (all four; v0 via self-fix override).
+    assert block.eventual_voter_count == 4
+
+
+def test_partition_chain_isolated_no_pending_deliveries_scheduled() -> None:
+    """Drops do not create pending-delivery queue entries. Isolated
+    validators have no record of in-window blocks."""
+    validators = [
+        Validator("v0", stake=1.0),
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=10000.0),
+        Validator("v3", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=PartitionScheduler(
+            isolated_group=frozenset({"v0", "v1"}),
+            partition_start_slot=0,
+            partition_end_slot=10,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(10):
+        chain.advance_slot(rng)
+    # Isolated validators should never have entries in the queue
+    # (drops don't enqueue).
+    assert "v0" not in chain._pending_deliveries
+    assert "v1" not in chain._pending_deliveries


### PR DESCRIPTION
## Summary

M7 phase 2b: `PartitionScheduler` with drop semantics. Builds directly on phase 2a's per-validator delivery queue (PR #77). Validators in the isolated group don't receive blocks during a finite partition window; outside the window, normal delivery resumes.

Tracks #31 (M7 milestone). Phase 2a shipped in PR #77; phase 1 in PR #75.

## What ships

### `PartitionScheduler` class

```python
@dataclass(slots=True, frozen=True)
class PartitionScheduler:
    isolated_group: frozenset[str] = field(default_factory=frozenset)
    partition_start_slot: int = 0
    partition_end_slot: int = 0
```

During `[partition_start_slot, partition_end_slot)`, isolated validators are absent from the delivery mapping. The chain's phase 2a logic treats absence as never-delivered: those validators are excluded from `eventual_voter_count` and from the per-block tally.

### Drop semantics, no replay

Phase 2b interpretation: the chain models ONE perspective (the canonical chain seen by non-isolated validators). Isolated validators don't see in-window blocks at all, ever — there's no replay or catch-up at heal time. Modeling fork reconciliation requires multi-chain bookkeeping that this simulator does not provide.

This is the honest minimum. Full multi-fork modeling (cartel produces its own chain during partition; merge-with-conflict-resolution at heal) is out of scope for phase 2b.

### Per-vote share invariant under drops

Drops shrink `eventual_voter_count`, so the per-vote share for surviving voters is correspondingly larger. This is the §4.3 voter-share semantic carried through honestly: validators who actually delivered earn proportionally more on a smaller-quorum block. Verified by `test_partition_chain_eventual_voter_count_reflects_drops`: with 2 of 5 validators isolated, `eventual_voter_count == 3` and per-vote share is `5.0 fee / 3 voters = ~1.667` (vs. `5.0 / 5 = 1.0` baseline).

### Proposer-self-fix interaction

If an isolated-group validator happens to be the proposer during the partition window, the existing phase 2a proposer-self-fix puts them in their own block's voter set. A proposer cannot be "partitioned" from a block they just produced. Verified by `test_partition_chain_isolated_proposer_self_fix`.

## Tests added (13 new)

### Unit tests on the scheduler (7)

- `test_partition_scheduler_satisfies_protocol`
- `test_partition_scheduler_negative_window_raises`
- `test_partition_scheduler_drops_isolated_during_window`
- `test_partition_scheduler_no_drops_before_window`
- `test_partition_scheduler_no_drops_at_or_after_end_slot`
- `test_partition_scheduler_empty_isolated_group_is_noop`
- `test_partition_scheduler_equal_start_and_end_is_noop`

### Chain-integration tests (6)

- `test_partition_chain_isolated_no_g_vote_during_window`
- `test_partition_chain_eventual_voter_count_reflects_drops`
- `test_partition_chain_heals_after_window`
- `test_partition_chain_liveness_during_window`
- `test_partition_chain_isolated_proposer_self_fix`
- `test_partition_chain_isolated_no_pending_deliveries_scheduled`

## Test plan

- [x] `python -m pytest -q` from `prototypes/poua-sim/`: **251 passing** (was 238 at end of phase 2a; +13 new phase 2b, zero regressions)
- [x] CI citations check expected to pass (no paper-side path citations affected)
- [x] Backward-compat: chains without a scheduler unaffected (verified by phase 2a's `test_phase2a_no_scheduler_keeps_queue_empty`)

## What this PR does NOT do

- **Multi-fork modeling**: cartel produces its own chain during partition. Out of scope.
- **Heal-time replay**: missed blocks are NOT delivered to isolated validators after the window. Real BFT chains might catch up; this simulator does not model that.
- **Conflict resolution**: which fork is canonical post-heal. Out of scope.
- **EclipseScheduler**: phase 3.
- **Scale benchmarks**: phase 4.

## Next phases

| Phase | Scope | Builds on |
|---|---|---|
| 3 | `EclipseScheduler`: target view restricted to cartel-proposed blocks | phases 2a + 2b |
| 4 | scale benchmarks (100 → 5000 validators) | independent |

Phase 3 is structurally similar to 2b: another scheduler class with a specific drop pattern (eclipse target sees only cartel blocks). The architecture work is fully done.
