### PR TITLE
Sim M7 phase 3: EclipseScheduler with target view restriction

### DIFF
--- a/prototypes/poua-sim/src/poua_sim/__init__.py
+++ b/prototypes/poua-sim/src/poua_sim/__init__.py
@@ -17,10 +17,11 @@ Layout (M4):
                          dispatch helpers (HONEST, EQUIVOCATE,
                          FREE_RIDE_VIA_VOTE_ONLY)
     poua_sim.adversary   Capital adversary (M3) + compound adversary (M4)
-    poua_sim.network     M7 phases 1+2b: NetworkScheduler protocol +
+    poua_sim.network     M7 phases 1+2b+3: NetworkScheduler protocol +
                          UniformLatencyScheduler +
                          AdversarialLatencyScheduler +
-                         PartitionScheduler
+                         PartitionScheduler +
+                         EclipseScheduler
 
 Future modules (M5, milestones tracked in
 https://github.com/ligate-io/ligate-research/issues/3):
@@ -71,6 +72,7 @@ from poua_sim.metrics import (
 )
 from poua_sim.network import (
     AdversarialLatencyScheduler,
+    EclipseScheduler,
     NetworkScheduler,
     PartitionScheduler,
     UniformLatencyScheduler,
@@ -108,6 +110,7 @@ __all__ = [
     "CapitalAdversary",
     "Chain",
     "CompoundAdversary",
+    "EclipseScheduler",
     "IMPLEMENTED_POLICIES",
     "Layer3Config",
     "NetworkScheduler",

--- a/prototypes/poua-sim/src/poua_sim/network.py
+++ b/prototypes/poua-sim/src/poua_sim/network.py
@@ -13,11 +13,13 @@ Per the M7 design doc at ``prototypes/poua-sim/docs/m7-design.md``:
 - **Phase 2a**: per-validator delivery queue in ``Chain`` so delayed
   blocks can be voted on at later slots; the ``g_vote`` denominator
   is fixed at block creation to preserve §4.3 voter-share semantics.
-- **Phase 2b** (this module's latest addition): ``PartitionScheduler``
-  with drop semantics. Validators in the isolated group do not receive
-  blocks during the partition window.
-- Phase 3: adds ``EclipseScheduler`` (target-validator view restricted
-  to cartel-proposed blocks).
+- **Phase 2b**: ``PartitionScheduler`` with drop semantics. Validators
+  in the isolated group do not receive blocks during the partition
+  window.
+- **Phase 3** (this module's latest addition): ``EclipseScheduler``.
+  A single eclipsed-target validator sees only cartel-proposed blocks
+  during the eclipse window; honest-proposed blocks are dropped to
+  that target.
 - Phase 4: scale benchmarks.
 
 Default behavior preserved: when ``Chain.network_scheduler is None``,
@@ -258,6 +260,105 @@ class PartitionScheduler:
             if in_partition and v.address in self.isolated_group:
                 # Drop: omit from mapping. Chain treats absence as
                 # never-delivered.
+                continue
+            result[v.address] = block_slot
+        return result
+
+
+@dataclass(slots=True, frozen=True)
+class EclipseScheduler:
+    """Eclipse a single target validator: their view is restricted to
+    cartel-proposed blocks during the eclipse window.
+
+    During ``[eclipse_start_slot, eclipse_end_slot)``, the
+    ``eclipsed_target`` only receives blocks whose proposer is in
+    ``cartel_addresses``. Honest-proposed blocks are dropped to that
+    target. All other validators receive blocks normally.
+
+    This models a network adversary that selectively isolates one
+    high-value validator while leaving the rest of the network healthy.
+    The classical eclipse attack: the adversary surrounds the target
+    with cartel-controlled peers and feeds them only cartel-curated
+    information.
+
+    Phase 3 interpretation, mirroring phase 2b:
+
+    - The chain models ONE perspective (canonical chain seen by
+      non-eclipsed validators). The eclipsed target's view of the
+      cartel sub-chain is unmodeled; we just record that the target
+      missed the honest blocks.
+    - No replay at eclipse end. Missed honest blocks stay missed.
+    - The target's reputation behavior under eclipse:
+      - Constant if neither work nor slashes accrue (the §4.3 update is
+        identity in that regime).
+      - Behind the honest baseline as honest validators continue to
+        accumulate ``g_vote`` work the target cannot share.
+    - Recovery dynamics post-eclipse: the target resumes normal
+      delivery for new blocks; relative reputation gap closes only as
+      the target accumulates work going forward.
+    - Empty ``cartel_addresses`` means the target sees no blocks at all
+      during the window (every proposer is non-cartel; everything
+      drops to the target).
+
+    Proposer-self-fix interaction: if the eclipsed target is the
+    proposer of a block, the chain's phase 2a self-fix puts them in
+    their own block's voter set. A target cannot be eclipsed from a
+    block they just proposed.
+
+    Parameters
+    ----------
+    eclipsed_target : str
+        Address of the validator being eclipsed.
+    cartel_addresses : frozenset[str]
+        Addresses of validators whose proposed blocks DO reach the
+        eclipsed target during the window. Empty set is allowed (target
+        sees no blocks at all during the window).
+    eclipse_start_slot : int
+        First slot of the eclipse window (inclusive).
+    eclipse_end_slot : int
+        First slot AFTER the eclipse window (exclusive). Must be
+        ``>= eclipse_start_slot``. Equality means an empty window
+        (no-op).
+
+    Raises
+    ------
+    ValueError
+        If ``eclipse_end_slot < eclipse_start_slot``.
+    """
+
+    eclipsed_target: str = ""
+    cartel_addresses: frozenset[str] = field(default_factory=frozenset)
+    eclipse_start_slot: int = 0
+    eclipse_end_slot: int = 0
+
+    def __post_init__(self) -> None:
+        if self.eclipse_end_slot < self.eclipse_start_slot:
+            raise ValueError(
+                f"eclipse_end_slot ({self.eclipse_end_slot}) must be "
+                f">= eclipse_start_slot ({self.eclipse_start_slot})"
+            )
+
+    def deliver(
+        self,
+        block_slot: int,
+        proposer_address: str,
+        recipients: list[Validator],
+    ) -> dict[str, int]:
+        in_eclipse = (
+            self.eclipse_start_slot <= block_slot < self.eclipse_end_slot
+        )
+        target_drops_this_block = (
+            in_eclipse
+            and proposer_address not in self.cartel_addresses
+        )
+        result: dict[str, int] = {}
+        for v in recipients:
+            if (
+                target_drops_this_block
+                and v.address == self.eclipsed_target
+            ):
+                # Drop: eclipsed target only sees cartel-proposed
+                # blocks during the window. Omit from mapping.
                 continue
             result[v.address] = block_slot
         return result

--- a/prototypes/poua-sim/tests/test_network.py
+++ b/prototypes/poua-sim/tests/test_network.py
@@ -30,6 +30,7 @@ import pytest
 from poua_sim.chain import Chain, constant_attestations
 from poua_sim.network import (
     AdversarialLatencyScheduler,
+    EclipseScheduler,
     NetworkScheduler,
     PartitionScheduler,
     UniformLatencyScheduler,
@@ -836,3 +837,289 @@ def test_partition_chain_isolated_no_pending_deliveries_scheduled() -> None:
     # (drops don't enqueue).
     assert "v0" not in chain._pending_deliveries
     assert "v1" not in chain._pending_deliveries
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: EclipseScheduler unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_eclipse_scheduler_satisfies_protocol() -> None:
+    scheduler = EclipseScheduler()
+    assert isinstance(scheduler, NetworkScheduler)
+
+
+def test_eclipse_scheduler_negative_window_raises() -> None:
+    with pytest.raises(ValueError, match=">= eclipse_start_slot"):
+        EclipseScheduler(eclipse_start_slot=20, eclipse_end_slot=10)
+
+
+def test_eclipse_drops_honest_proposed_blocks_for_target() -> None:
+    """During the eclipse window, the target is dropped from blocks
+    proposed by validators outside the cartel."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
+    scheduler = EclipseScheduler(
+        eclipsed_target="v0",
+        cartel_addresses=frozenset({"v3"}),
+        eclipse_start_slot=0,
+        eclipse_end_slot=10,
+    )
+    # v1 proposes (honest, not in cartel) at slot 5 (in window).
+    delivery = scheduler.deliver(
+        block_slot=5,
+        proposer_address="v1",
+        recipients=validators,
+    )
+    # Eclipsed target (v0) is dropped; everyone else sees the block.
+    assert "v0" not in delivery
+    for addr in ("v1", "v2", "v3", "v4"):
+        assert delivery[addr] == 5
+
+
+def test_eclipse_allows_cartel_proposed_blocks_for_target() -> None:
+    """During the eclipse window, the target receives blocks proposed
+    by cartel members."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
+    scheduler = EclipseScheduler(
+        eclipsed_target="v0",
+        cartel_addresses=frozenset({"v3", "v4"}),
+        eclipse_start_slot=0,
+        eclipse_end_slot=10,
+    )
+    # Cartel member v3 proposes during window.
+    delivery = scheduler.deliver(
+        block_slot=5,
+        proposer_address="v3",
+        recipients=validators,
+    )
+    # Target v0 DOES receive cartel-proposed blocks.
+    assert delivery["v0"] == 5
+    # Everyone else also receives.
+    assert set(delivery.keys()) == {"v0", "v1", "v2", "v3", "v4"}
+
+
+def test_eclipse_no_drops_outside_window() -> None:
+    """Outside the eclipse window, target receives all blocks regardless
+    of proposer."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = EclipseScheduler(
+        eclipsed_target="v0",
+        cartel_addresses=frozenset({"v2"}),
+        eclipse_start_slot=10,
+        eclipse_end_slot=20,
+    )
+    # Slot 5: before window. Honest proposer; target should receive.
+    delivery_before = scheduler.deliver(
+        block_slot=5, proposer_address="v1", recipients=validators
+    )
+    assert delivery_before["v0"] == 5
+    # Slot 20: at window end (exclusive). Target should receive.
+    delivery_at_end = scheduler.deliver(
+        block_slot=20, proposer_address="v1", recipients=validators
+    )
+    assert delivery_at_end["v0"] == 20
+
+
+def test_eclipse_empty_cartel_drops_all_blocks_for_target() -> None:
+    """With empty ``cartel_addresses``, every block during the window
+    has a non-cartel proposer and the target sees nothing."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(3)]
+    scheduler = EclipseScheduler(
+        eclipsed_target="v0",
+        cartel_addresses=frozenset(),
+        eclipse_start_slot=0,
+        eclipse_end_slot=10,
+    )
+    # Any proposer during window: target dropped (no proposer is in
+    # the empty cartel set).
+    delivery = scheduler.deliver(
+        block_slot=5, proposer_address="v1", recipients=validators
+    )
+    assert "v0" not in delivery
+    # Other validators still receive normally.
+    assert delivery["v1"] == 5
+    assert delivery["v2"] == 5
+
+
+def test_eclipse_other_validators_unaffected() -> None:
+    """Eclipse only affects the target; other validators (cartel and
+    non-cartel alike) receive every block."""
+    validators = [Validator(f"v{i}", stake=100.0) for i in range(5)]
+    scheduler = EclipseScheduler(
+        eclipsed_target="v0",
+        cartel_addresses=frozenset({"v3"}),
+        eclipse_start_slot=0,
+        eclipse_end_slot=10,
+    )
+    delivery = scheduler.deliver(
+        block_slot=5, proposer_address="v1", recipients=validators
+    )
+    # v0 dropped (eclipsed); v1, v2, v3, v4 all delivered.
+    assert "v0" not in delivery
+    for addr in ("v1", "v2", "v3", "v4"):
+        assert delivery[addr] == 5
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: EclipseScheduler chain-integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_eclipse_chain_target_sees_no_honest_blocks_during_window() -> None:
+    """During the eclipse window, the target's voter membership only
+    appears on cartel-proposed blocks."""
+    # v0 = eclipsed honest target. Make v2 the dominant proposer
+    # (heavy stake) so blocks are usually honest.
+    validators = [
+        Validator("v0", stake=100.0),  # target
+        Validator("v1", stake=1.0),    # cartel
+        Validator("v2", stake=10000.0),  # dominant honest proposer
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=EclipseScheduler(
+            eclipsed_target="v0",
+            cartel_addresses=frozenset({"v1"}),
+            eclipse_start_slot=0,
+            eclipse_end_slot=20,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        chain.advance_slot(rng)
+    # Inspect each block: target v0 should appear in voters ONLY for
+    # cartel-proposed blocks.
+    for block in chain.blocks:
+        if block.proposer == "v1":
+            # Cartel-proposed: target receives, votes.
+            assert "v0" in block.voters
+        elif block.proposer == "v0":
+            # Target is the proposer (proposer-self-fix).
+            assert "v0" in block.voters
+        else:
+            # Honest non-target proposer: target dropped.
+            assert "v0" not in block.voters
+
+
+def test_eclipse_chain_target_g_vote_only_from_cartel_blocks() -> None:
+    """The eclipsed target only accumulates ``g_vote`` on cartel-
+    proposed blocks during the window. Reputation work from honest
+    blocks is missed entirely."""
+    validators = [
+        Validator("v0", stake=100.0),  # target
+        Validator("v1", stake=1.0),    # cartel
+        Validator("v2", stake=10000.0),  # dominant honest proposer
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5, fee=1.0),
+        network_scheduler=EclipseScheduler(
+            eclipsed_target="v0",
+            cartel_addresses=frozenset({"v1"}),
+            eclipse_start_slot=0,
+            eclipse_end_slot=20,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        chain.advance_slot(rng)
+    # Count cartel-proposed blocks during window.
+    cartel_blocks = sum(1 for b in chain.blocks if b.proposer == "v1")
+    target = chain._validators_by_address["v0"]
+    # Target's g_vote = (cartel_blocks * 5.0 fee) / eventual_voter_count
+    # eventual_voter_count for cartel blocks is len(non-dropped) which
+    # is len(validators) = 3 (cartel proposer doesn't drop the target,
+    # so all 3 see the block).
+    expected_g_vote = cartel_blocks * (5.0 / 3)
+    assert target.epoch_g_vote == expected_g_vote
+
+
+def test_eclipse_chain_recovery_after_window() -> None:
+    """After the eclipse window ends, the target resumes normal
+    delivery for new blocks."""
+    validators = [
+        Validator("v0", stake=100.0),  # target
+        Validator("v1", stake=1.0),    # cartel
+        Validator("v2", stake=10000.0),  # honest proposer
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=EclipseScheduler(
+            eclipsed_target="v0",
+            cartel_addresses=frozenset({"v1"}),
+            eclipse_start_slot=0,
+            eclipse_end_slot=5,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    # Slots 0-4: window active.
+    for _ in range(5):
+        chain.advance_slot(rng)
+    # Slot 5: window over; produce a (likely honest) block.
+    block_after = chain.advance_slot(rng)
+    if block_after.proposer == "v2":
+        # Honest proposer; target should now be in voter set.
+        assert "v0" in block_after.voters
+        assert block_after.eventual_voter_count == 3
+
+
+def test_eclipse_chain_target_proposer_self_fix() -> None:
+    """If the eclipsed target is the proposer of a block, the
+    proposer-self-fix puts them in their own voter set, even though
+    the eclipse would otherwise drop them."""
+    # Stake-stack v0 (the target) so it's the proposer.
+    validators = [
+        Validator("v0", stake=10000.0),  # target AND heavy proposer
+        Validator("v1", stake=1.0),
+        Validator("v2", stake=1.0),
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=EclipseScheduler(
+            eclipsed_target="v0",
+            cartel_addresses=frozenset({"v1"}),
+            eclipse_start_slot=0,
+            eclipse_end_slot=5,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    block = chain.advance_slot(rng)
+    assert block.proposer == "v0"
+    # Self-fix: v0 in voters even though they're the eclipse target.
+    assert "v0" in block.voters
+    # Other validators also receive (target is the proposer, so the
+    # eclipse "drop" rule doesn't apply: proposer IS the target).
+    # In our scheduler, the drop is keyed on (target == eclipsed AND
+    # proposer NOT in cartel). When target IS the proposer, the
+    # condition is False (target's own block is "from non-cartel", but
+    # the target sees their own block via self-fix). So all three
+    # validators are in voters.
+    assert block.eventual_voter_count == 3
+
+
+def test_eclipse_chain_no_pending_for_target_on_dropped_blocks() -> None:
+    """Drops do not enqueue pending deliveries for the target."""
+    validators = [
+        Validator("v0", stake=100.0),  # target
+        Validator("v1", stake=1.0),    # cartel
+        Validator("v2", stake=10000.0),  # honest proposer
+    ]
+    chain = Chain(
+        validators=validators,
+        attestation_generator=constant_attestations(n_per_block=5),
+        network_scheduler=EclipseScheduler(
+            eclipsed_target="v0",
+            cartel_addresses=frozenset({"v1"}),
+            eclipse_start_slot=0,
+            eclipse_end_slot=10,
+        ),
+    )
+    rng = np.random.default_rng(0)
+    for _ in range(10):
+        chain.advance_slot(rng)
+    # Target should never have entries in the queue (drops don't
+    # enqueue, and cartel-proposed deliveries are immediate, not late).
+    assert "v0" not in chain._pending_deliveries


### PR DESCRIPTION
## Summary

M7 phase 3: `EclipseScheduler`. Builds on phase 2b's drop infrastructure (PR #78). A single eclipsed target validator sees only cartel-proposed blocks during the eclipse window; honest-proposed blocks are dropped to that target. All other validators are unaffected.

Tracks #31 (M7 milestone). Phase 2b shipped in PR #78; phase 2a in #77; phase 1 in #75.

## What ships

### `EclipseScheduler` class

```python
@dataclass(slots=True, frozen=True)
class EclipseScheduler:
    eclipsed_target: str = ""
    cartel_addresses: frozenset[str] = field(default_factory=frozenset)
    eclipse_start_slot: int = 0
    eclipse_end_slot: int = 0
```

Drop rule: during `[eclipse_start_slot, eclipse_end_slot)`, the target is omitted from `delivery` for any block whose proposer is NOT in `cartel_addresses`. Cartel-proposed blocks reach the target normally. All other validators always receive blocks.

### Eclipse interpretation

The classical eclipse attack: the adversary surrounds the target with cartel-controlled peers and feeds them only cartel-curated information. Models a network adversary that selectively isolates one high-value validator while leaving the rest of the network healthy.

Mirroring phase 2b's honest minimum:
- Single chain perspective (canonical, seen by non-eclipsed validators)
- No replay: missed honest blocks stay missed
- No multi-fork modeling
- Reputation behavior under eclipse: target accumulates `g_vote` only on cartel-proposed blocks, falling behind the honest baseline as the network continues to accumulate work without them

### Recovery semantics

After the eclipse window ends, the target resumes normal delivery for new blocks. Relative reputation gap closes only as the target accumulates work going forward. Recovery dynamics curve (an actual figure) is out of scope for this PR; would be a follow-up `scripts/run_eclipse_recovery.py` if needed.

### Empty cartel edge case

`cartel_addresses=frozenset()` means the target sees NO blocks during the window (no proposer matches the empty cartel set). Useful for stress-testing total information starvation.

### Proposer-self-fix interaction

If the eclipsed target IS the proposer of a block, the existing phase 2a self-fix puts them in their own voter set. A target cannot be eclipsed from a block they just produced. Verified by `test_eclipse_chain_target_proposer_self_fix`.

## Tests added (12 new)

### Unit tests on the scheduler (7)

- `test_eclipse_scheduler_satisfies_protocol`
- `test_eclipse_scheduler_negative_window_raises`
- `test_eclipse_drops_honest_proposed_blocks_for_target`
- `test_eclipse_allows_cartel_proposed_blocks_for_target`
- `test_eclipse_no_drops_outside_window`
- `test_eclipse_empty_cartel_drops_all_blocks_for_target`
- `test_eclipse_other_validators_unaffected`

### Chain-integration tests (5)

- `test_eclipse_chain_target_sees_no_honest_blocks_during_window`
- `test_eclipse_chain_target_g_vote_only_from_cartel_blocks`
- `test_eclipse_chain_recovery_after_window`
- `test_eclipse_chain_target_proposer_self_fix`
- `test_eclipse_chain_no_pending_for_target_on_dropped_blocks`

## Test plan

- [x] `python -m pytest -q` from `prototypes/poua-sim/`: **263 passing** (was 251 at end of phase 2b; +12 new phase 3, zero regressions)
- [x] CI citations check expected to pass (no paper-side path citations affected)
- [x] Backward-compat preserved across phases 1, 2a, 2b, 3 (no scheduler = synchronous baseline)

## What this PR does NOT do

- **Eclipse-recovery curve figure**: a separate `scripts/run_eclipse_recovery.py` ship. Out of scope here.
- **Multi-target eclipse**: only single-target. Multi-target would need a `frozenset[str]` instead of `str` for `eclipsed_target`. Adding later is trivial if needed.
- **Cross-domain interactions** (e.g. eclipse + partition simultaneously): each scheduler is a single-purpose class; combining requires a composite scheduler that's out of scope.
- **Scale benchmarks**: phase 4.

## M7 progress

| Phase | Status | PR |
|---|---|---|
| 1 (latency schedulers) | ✅ merged | #75 |
| 2a (delivery queue + proposer self-fix) | ✅ merged | #77 |
| 2b (PartitionScheduler + drops) | ✅ merged | #78 |
| **3 (EclipseScheduler)** | **⏸ this PR** | **#79** |
| 4 (scale benchmarks) | not started | — |

After this PR merges, all four NetworkScheduler implementations shipped. Phase 4 (scale) is independent benchmarking work.
