### PR TITLE
chore: add CLA Assistant Lite + canonical CLA.md

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PERSONAL_ACCESS_TOKEN required only if signatures are stored
+          # in a separate org-level repo via remote-organization-name +
+          # remote-repository-name. Per-repo signing (the default) uses
+          # GITHUB_TOKEN; leave the PAT commented until we consolidate.
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/ligate-io/ligate-chain/blob/main/CLA.md'
+          branch: 'cla/signatures'
+          allowlist: 'sstefdev,dependabot[bot],*[bot]'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,55 @@
+# Ligate Labs Inc. Contribution License Agreement
+
+This Contribution License Agreement (the "CLA") is between the individual set forth in the signature block ("You") and Ligate Labs Inc. (the "Company") effective as of the date of Your signature. It sets forth the terms pursuant to which You provide Contributions to the Company.
+
+By signing, You accept and agree to the following terms and conditions for Your present and future Contributions submitted to the Company. In return, the Company will not use Your Contributions in a way that is contrary to the Company's business objectives. Except for the license granted herein to the Company and recipients of software distributed by the Company, You reserve all right, title, and interest in and to Your Contributions.
+
+## Definitions
+
+**Contribution** means any original work of authorship, including any modifications or additions to an existing work, that You intentionally submit to the Company for inclusion in or documentation of any of the products owned or managed by the Company (the "Work").
+
+**Submit** means any form of electronic, verbal, or written communication sent to the Company or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems managed by or on behalf of the Company, for the purpose of discussing and improving the Work. This excludes communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## Copyright License
+
+Subject to the terms and conditions of this CLA, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## Patent License
+
+Subject to the terms and conditions of this CLA, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work. This license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit), alleging that Your Contribution or the Work to which You have contributed constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this CLA for that Contribution or Work will terminate as of the date such litigation is filed.
+
+## Representations and Warranties
+
+You represent and warrant to the Company that:
+
+1. You are legally entitled to grant the above license. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, then You represent and warrant that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to the Company, or that Your employer has executed a separate CLA with the Company.
+
+2. Each of Your Contributions is Your original creation (see section 6 for submissions on behalf of others).
+
+3. Your Contribution submissions include complete details of any third-party license or other restriction (including but not limited to related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## Support; Disclaimer
+
+You are not expected to provide support for Your Contributions except to the extent You desire to do so. You may provide support for free, for a fee, or not at all.
+
+Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including without limitation any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## Third-Party Works
+
+If You wish to submit work that is not Your original creation, You may submit it to the Company separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including but not limited to related patents, trademarks, and license agreements) of which You are personally aware and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]."
+
+You agree to notify the Company of any facts or circumstances of which You become aware that would make Your representations in this CLA inaccurate in any respect.
+
+## General
+
+This CLA is the entire understanding and agreement with respect to the subject matter hereof and supersedes any and all prior or contemporaneous representations, understandings, and agreements between the parties regarding the same.
+
+If any part of this CLA is found to be unenforceable, the remaining portions of this CLA will remain in full force and effect. No modification of or amendment to this CLA, nor any waiver of any rights under this CLA, will be effective unless in writing signed by the party to be charged. The waiver of any breach or default will not constitute a waiver of any other right under this CLA or any subsequent breach or default.
+
+Nothing in this CLA creates, and the parties do not intend to create, any partnership or joint venture between themselves. Either party may freely assign this CLA. This CLA is binding upon and will inure to the benefit of a party's successors and permitted assigns.
+
+This CLA will be governed by the laws of the State of Delaware. Exclusive jurisdiction of any and all disputes hereunder will be in the state and federal courts of Delaware.
+
+This CLA may be executed in counterparts with the same effect as if all signatories had signed the same document.


### PR DESCRIPTION
## Summary

Adds CLA gating to ligate-research. This repo houses protocol-design papers (PoUA paper at v0.7.2 + reference simulators + adversarial test harnesses) and currently accepts external contributions — peer reviewers, PhD students, etc — without a CLA workflow.

## What this PR does

Drops in the canonical CLA setup matching ligate-chain, ligate-api, ligate-cli, ligate-js, and sovereign-sdk:

- `.github/workflows/cla.yml` — CLA Assistant Lite action wired identically to ligate-chain#257. Gates `pull_request_target` from non-allowlisted contributors.
- `CLA.md` — verbatim copy of the canonical Ligate Labs CLA from ligate-chain/CLA.md.

Both files are byte-identical to ligate-chain's; the CLA workflow's `path-to-document` points at ligate-chain/CLA.md as the single source of truth.

## Dual-license note

ligate-research is dual-licensed Apache-2.0 (code: simulators, harnesses) + CC-BY-4.0 (papers). The CLA covers contributions to either side — code patches to simulators and paper fixes from peer reviewers both flow through PRs to this repo and both need the IP grant.

## Allowlist

Same as other repos: `sstefdev`, `dependabot[bot]`, `*[bot]`.

## Why now

Closing the same gap as the explorer CLA PR (filed in parallel). Pre-launch is the right time to canonicalize this since post-launch any external peer-reviewer PR to the PoUA paper would land without a clear copyright trail.

## Test plan

- [ ] PR triggers CLA Assistant workflow
- [ ] Merge this PR
- [ ] Next external PR prompts for CLA signature

## Sibling PR

ligate-io/ligate-explorer — same change filed in parallel.