### PR TITLE
chore(cla): point path-to-document at this repo's CLA, not chain's

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,6 @@ jobs:
           # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/ligate-io/ligate-chain/blob/main/CLA.md'
+          path-to-document: 'https://github.com/ligate-io/ligate-research/blob/main/CLA.md'
           branch: 'cla/signatures'
           allowlist: 'sstefdev,dependabot[bot],*[bot]'


### PR DESCRIPTION
Companion to the cla/signatures branch bootstrap (just pushed alongside this). The CLA workflow's path-to-document URL was inherited from the chain repo's template and never updated. Both CLA.md files are textually identical today, but external contributors who click 'Please sign the CLA' should land on this repo's CLA, not the chain repo's.

PR #86 needed `--admin` merge because the `cla/signatures` branch didn't exist. With that branch now bootstrapped and `sstefdev` already in the allowlist, this PR's own CLA check should pass cleanly — that's the end-to-end verification.

## Test plan

- [x] cla/signatures branch exists on origin (sha d6d2bee, contains `signatures/version1/cla.json = {"signedContributors":[]}`)
- [ ] CLA Assistant check on this PR turns green (validates the bootstrap end-to-end)
- [ ] After merge, future contributor PRs work without `--admin` (allowlisted users auto-pass; non-allowlisted prompted to comment the sign phrase)

## Out of scope

- Cleaning the cla/signatures branch to be a true orphan (currently carries main history). Functionally identical for the action; cosmetic only.
- Chain repo CLA setup is already correct (cla/signatures exists, URL points at chain's own CLA, recent PRs all pass the check).
