### PR TITLE
sim(native-delegation): v0.3 M3 - canonical grant encoding + cross-language test vectors

### DIFF
--- a/prototypes/native-delegation-sim/README.md
+++ b/prototypes/native-delegation-sim/README.md
@@ -2,9 +2,22 @@
 
 Reference simulator for **Native Delegation**, the runtime primitive specified in [`papers/native-delegation`](../../papers/native-delegation/).
 
-**Latest**: v0.2.0 (2026-05-20). M2 closed: lifecycle state machine (paper §4.4) + Monte Carlo strategy search (§5.5) + Theorem 1 validation figure. 56 tests passing.
+**Latest**: v0.3.0 (2026-05-22). M3 closed: canonical grant encoding (paper §3.4 + Appendix B) with `GrantSpec`, `encode_grant_spec`, `decode_grant_spec`, full bound checks, and cross-language test vectors. 91 tests passing.
 
-**Status**: M1 + M2 substantive. M3 (cross-language test vectors + adversarial-strategy extension) is post-v0.2-paper-ship work.
+**Status**: M1 + M2 + M3 substantive. M4 (strategic-adversary extension where the hot key picks misbehavior actions to maximize $G_{\text{misbehave}} - w_h \cdot \Lambda$) is post-M3 work; M5 (full chain integration test against `ligate-chain`) is planned once the chain ships native delegation.
+
+## v0.3 (M3): canonical grant encoding
+
+The M3 milestone adds a byte-exact serialization of the paper's §3.4 grant tuple. Future Rust / TypeScript implementations of Ligate Chain can produce identical bytes by following the spec in `src/native_delegation_sim/encoding.py`.
+
+What ships:
+
+- `GrantSpec` dataclass with the full §3.4 + Appendix B tuple (master_addr, hot_addr, nonce, height_start, height_end, rule, w_m, w_h, schemas, actions) with all protocol-level bound checks
+- `encode_grant_spec()` -> `bytes`: deterministic v1 encoding with version tag, big-endian numeric fields, fixed-point weights at 10^-4 precision, ascending-sorted schemas/actions
+- `decode_grant_spec(bytes)` -> `GrantSpec`: roundtrip with bound-check enforcement on input
+- `test_vectors/grant_encoding.json`: 6 canonical test vectors with byte-exact `encoded_hex` outputs
+
+`scripts/regenerate_test_vectors.py` rebuilds the vectors from the Python reference. Cross-language conformance check: encode each vector's `input`, hex-encode the bytes, compare to `expected.encoded_hex` byte-by-byte.
 
 ## What this simulator validates
 

--- a/prototypes/native-delegation-sim/pyproject.toml
+++ b/prototypes/native-delegation-sim/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "native-delegation-sim"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reference simulator for Native Delegation, the runtime primitive on Ligate Chain that supports hot-key / master-key separation with slashing-inheritance"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/prototypes/native-delegation-sim/scripts/regenerate_test_vectors.py
+++ b/prototypes/native-delegation-sim/scripts/regenerate_test_vectors.py
@@ -1,0 +1,169 @@
+"""Regenerate cross-language test vectors under ``test_vectors/``.
+
+Each vector is computed from the Python reference encoder. A future
+Rust / TypeScript implementation can load these and verify byte-exact
+identity.
+
+Vectors cover §3.4 + Appendix B canonical grant encoding:
+
+- ``grant_encoding.json``: encode-then-decode roundtrip cases across
+  the parameter space (minimal, recommended calibration, maximum-u64
+  heights, all three RuleTag values, varied scope cardinalities)
+
+Usage:
+    python scripts/regenerate_test_vectors.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from native_delegation_sim import (
+    GrantSpec,
+    RuleTag,
+    encode_grant_spec,
+)
+
+TOL = 1e-12
+
+
+def grant_encoding_vectors() -> list[dict]:
+    """§3.4 grant encoding test cases."""
+    cases = []
+
+    # Case 1: minimal grant, all zero, MASTER_ONLY
+    g1 = GrantSpec(
+        master_addr=b"\x00" * 32,
+        hot_addr=b"\x00" * 32,
+        nonce=0,
+        height_start=0,
+        height_end=0,
+        rule=RuleTag.MASTER_ONLY,
+        w_m=1.0,
+        w_h=0.0,
+    )
+    cases.append(_vector("minimal_grant_master_only", g1))
+
+    # Case 2: §5.5 recommended calibration with full scope
+    g2 = GrantSpec(
+        master_addr=b"\xAA" * 32,
+        hot_addr=b"\xBB" * 32,
+        nonce=42,
+        height_start=1_000,
+        height_end=10_000,
+        rule=RuleTag.BOTH_SLASHED,
+        w_m=0.7,
+        w_h=0.3,
+        schemas=(b"\x0F" * 32,),
+        actions=(b"\x42" * 32,),
+    )
+    cases.append(_vector("recommended_calibration", g2))
+
+    # Case 3: HOT_ONLY rule (paper §5.3)
+    g3 = GrantSpec(
+        master_addr=b"\x11" * 32,
+        hot_addr=b"\x22" * 32,
+        nonce=1,
+        height_start=100,
+        height_end=200,
+        rule=RuleTag.HOT_ONLY,
+        w_m=0.0,
+        w_h=1.0,
+    )
+    cases.append(_vector("hot_only_rule", g3))
+
+    # Case 4: multi-schema, multi-action scope (out-of-order input)
+    g4 = GrantSpec(
+        master_addr=b"\x33" * 32,
+        hot_addr=b"\x44" * 32,
+        nonce=7,
+        height_start=500,
+        height_end=1500,
+        rule=RuleTag.BOTH_SLASHED,
+        w_m=0.6,
+        w_h=0.4,
+        # Input in descending order; encoder sorts ascending.
+        schemas=(b"\xCC" * 32, b"\xAA" * 32, b"\xBB" * 32),
+        actions=(b"\x99" * 32, b"\x11" * 32),
+    )
+    cases.append(_vector("multi_schema_unsorted_input", g4))
+
+    # Case 5: maximum u64 boundary
+    max_u64 = 2**64 - 1
+    g5 = GrantSpec(
+        master_addr=b"\xFF" * 32,
+        hot_addr=b"\xEE" * 32,
+        nonce=max_u64,
+        height_start=max_u64 - 1,
+        height_end=max_u64,
+        rule=RuleTag.BOTH_SLASHED,
+        w_m=0.5,
+        w_h=0.5,
+    )
+    cases.append(_vector("max_u64_boundary", g5))
+
+    # Case 6: weight quantization edge case (0.0001 boundary)
+    g6 = GrantSpec(
+        master_addr=b"\x00" * 32,
+        hot_addr=b"\x01" * 32,
+        nonce=1,
+        height_start=0,
+        height_end=1,
+        rule=RuleTag.BOTH_SLASHED,
+        w_m=0.9999,
+        w_h=0.0001,
+    )
+    cases.append(_vector("weight_min_granularity", g6))
+
+    return cases
+
+
+def _vector(name: str, g: GrantSpec) -> dict:
+    """Build a vector entry from a GrantSpec."""
+    encoded = encode_grant_spec(g)
+    return {
+        "name": name,
+        "section": "§3.4 + Appendix B",
+        "input": {
+            "master_addr": "0x" + g.master_addr.hex(),
+            "hot_addr": "0x" + g.hot_addr.hex(),
+            "nonce": g.nonce,
+            "height_start": g.height_start,
+            "height_end": g.height_end,
+            "rule": g.rule.name,
+            "w_m": g.w_m,
+            "w_h": g.w_h,
+            "schemas": ["0x" + s.hex() for s in g.schemas],
+            "actions": ["0x" + a.hex() for a in g.actions],
+        },
+        "expected": {
+            "encoded_hex": encoded.hex(),
+            "encoded_length": len(encoded),
+        },
+        "tolerance": TOL,
+    }
+
+
+def main() -> None:
+    base = Path(__file__).parent.parent / "test_vectors"
+    base.mkdir(exist_ok=True)
+
+    files = [
+        ("grant_encoding.json", grant_encoding_vectors()),
+    ]
+
+    for filename, vectors in files:
+        path = base / filename
+        with path.open("w") as f:
+            json.dump(
+                {"version": "0.3.0", "vectors": vectors},
+                f,
+                indent=2,
+                sort_keys=False,
+            )
+        print(f"wrote {path} ({len(vectors)} vectors)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/native-delegation-sim/src/native_delegation_sim/__init__.py
+++ b/prototypes/native-delegation-sim/src/native_delegation_sim/__init__.py
@@ -1,26 +1,39 @@
 """native-delegation-sim: reference simulator for Native Delegation.
 
+v0.3 (M3, 2026-05-22): adds the §3.4 + Appendix B canonical grant
+encoding for cross-language conformance. Future Rust / TypeScript
+implementations can produce byte-identical output by following the
+``encoding.py`` spec.
+
 v0.2 (M2, 2026-05-20): adds lifecycle state machine (paper §4.4) and
 Monte Carlo strategy search over the §5.5 satisfying region with
-stochastic compromise probability. M1 (v0.1) shipped the determinstic
-grid sweep + the four-property predicates.
+stochastic compromise probability.
+
+v0.1 (M1, 2026-05-19): deterministic grid sweep + four-property
+predicates.
 
 See ``papers/native-delegation/`` for the paper this simulator
 validates, and ``README.md`` for the milestone plan.
 """
 
+from native_delegation_sim.encoding import (
+    GrantSpec,
+    RuleTag,
+    decode_grant_spec,
+    encode_grant_spec,
+)
 from native_delegation_sim.grant import Grant, InheritanceRule
 from native_delegation_sim.lifecycle import GrantLifecycle, GrantState
 from native_delegation_sim.slashing import (
     SlashOutcome,
     apply_slash,
-    expected_master_utility,
     expected_hot_utility,
+    expected_master_utility,
+    satisfies_all_properties,
     satisfies_p1,
     satisfies_p2,
     satisfies_p3,
     satisfies_p4,
-    satisfies_all_properties,
 )
 from native_delegation_sim.strategy_search import (
     CellResult,
@@ -30,13 +43,12 @@ from native_delegation_sim.strategy_search import (
 )
 from native_delegation_sim.validator import Validator
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
+    # M1
     "Grant",
     "InheritanceRule",
-    "GrantLifecycle",
-    "GrantState",
     "Validator",
     "SlashOutcome",
     "apply_slash",
@@ -47,8 +59,16 @@ __all__ = [
     "satisfies_p3",
     "satisfies_p4",
     "satisfies_all_properties",
+    # M2
+    "GrantLifecycle",
+    "GrantState",
     "CellResult",
     "SearchResults",
     "StochasticAdversary",
     "run_strategy_search",
+    # M3
+    "GrantSpec",
+    "RuleTag",
+    "encode_grant_spec",
+    "decode_grant_spec",
 ]

--- a/prototypes/native-delegation-sim/src/native_delegation_sim/encoding.py
+++ b/prototypes/native-delegation-sim/src/native_delegation_sim/encoding.py
@@ -1,0 +1,383 @@
+"""§3.4 + Appendix B canonical grant encoding (M3).
+
+This module specifies the byte-exact serialization of the paper's grant
+tuple so that future Rust / TypeScript implementations of Ligate Chain
+can produce identical bytes. The encoding is **deterministic,
+fixed-shape-where-possible, and self-describing for variable parts**:
+two parties given the same logical grant produce byte-identical output.
+
+The format is version-tagged (currently ``v1``). Future encodings (e.g.,
+post-quantum signature scheme migration, see paper §10.4) will bump the
+version byte; v1 readers reject non-v1 inputs.
+
+Field layout (big-endian, all sizes in bytes):
+
+::
+
+    offset  size   field
+    ------  -----  ----------------------------------------------------
+       0     1     version tag (0x01 for v1)
+       1    32     master_addr (left-padded with zeros)
+      33    32     hot_addr (left-padded with zeros)
+      65     8     nonce (u64 BE)
+      73     8     height_start (u64 BE)
+      81     8     height_end (u64 BE)
+      89     1     rule_tag (0=MASTER_ONLY, 1=HOT_ONLY, 2=BOTH_SLASHED)
+      90     4     w_m (u32 BE, fixed-point with 10^4 scale; 0.7 -> 7000)
+      94     4     w_h (u32 BE, fixed-point with 10^4 scale)
+      98     4     schemas_len (u32 BE)
+     102    32 * schemas_len  schemas (each 32B, sorted ascending)
+                  -- variable region --
+                   4     actions_len (u32 BE)
+                  32 * actions_len  actions (each 32B, sorted ascending)
+
+The total encoded length is ``102 + 4 + 32*|schemas| + 4 + 32*|actions|``.
+
+Reference paper section numbers in this docstring refer to
+native-delegation v0.2 §3.4 and Appendix B.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+VERSION_TAG: int = 0x01  # v1 encoding
+ADDR_LEN: int = 32  # bytes per address / schema-id / action-id
+WEIGHT_SCALE: int = 10_000  # fixed-point scale for (w_m, w_h)
+
+# Sizes of fixed-width fields, in bytes.
+SIZE_VERSION: int = 1
+SIZE_ADDR: int = 32
+SIZE_U64: int = 8
+SIZE_RULE_TAG: int = 1
+SIZE_U32: int = 4
+
+# Minimum encoded length (empty schemas + empty actions).
+MIN_ENCODED_LEN: int = (
+    SIZE_VERSION  # version tag
+    + 2 * SIZE_ADDR  # master + hot
+    + 3 * SIZE_U64  # nonce + height_start + height_end
+    + SIZE_RULE_TAG  # rule discriminant
+    + 2 * SIZE_U32  # w_m + w_h
+    + SIZE_U32  # schemas_len
+    + SIZE_U32  # actions_len
+)
+assert MIN_ENCODED_LEN == 106
+
+
+class RuleTag(IntEnum):
+    """§3.4 inheritance rule discriminant, byte-exact."""
+
+    MASTER_ONLY = 0
+    HOT_ONLY = 1
+    BOTH_SLASHED = 2
+
+
+# ----------------------------------------------------------------------------
+# Data class
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GrantSpec:
+    """The §3.4 grant tuple, with all fields needed for canonical encoding.
+
+    This is a richer record than the simulator's M1/M2 ``Grant`` class
+    (which only needs master_addr + hot_addr + rule + weights for the
+    §5.5 theorem work). M3 extends to the full paper §3.4 tuple so the
+    encoding can serialize what the chain actually stores on-chain.
+
+    Attributes
+    ----------
+    master_addr
+        32 bytes. The master key's on-chain address.
+    hot_addr
+        32 bytes. The hot key's on-chain address.
+    nonce
+        u64. Per-master strictly-increasing replay counter.
+    height_start, height_end
+        u64. Block heights bounding the grant's validity window.
+    rule
+        :class:`RuleTag`. Slashing-inheritance rule discriminant.
+    w_m, w_h
+        Floats in [0, 1] with 10^-4 precision. The §5.5 inheritance
+        weights, stored as fixed-point u32 in the encoding.
+    schemas, actions
+        Lists of 32-byte schema-ids and action-ids respectively. The
+        encoding sorts each ascending before serialization to ensure
+        determinism regardless of input order.
+    """
+
+    master_addr: bytes
+    hot_addr: bytes
+    nonce: int
+    height_start: int
+    height_end: int
+    rule: RuleTag
+    w_m: float
+    w_h: float
+    schemas: tuple[bytes, ...] = field(default_factory=tuple)
+    actions: tuple[bytes, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _validate_grant_spec(self)
+
+
+def _validate_grant_spec(g: GrantSpec) -> None:
+    """Paper §3.4 + Appendix B bound checks."""
+    if len(g.master_addr) != ADDR_LEN:
+        raise ValueError(
+            f"master_addr must be {ADDR_LEN} bytes, got {len(g.master_addr)}"
+        )
+    if len(g.hot_addr) != ADDR_LEN:
+        raise ValueError(
+            f"hot_addr must be {ADDR_LEN} bytes, got {len(g.hot_addr)}"
+        )
+    if not (0 <= g.nonce < 2**64):
+        raise ValueError(f"nonce {g.nonce} not a u64")
+    if not (0 <= g.height_start < 2**64):
+        raise ValueError(f"height_start {g.height_start} not a u64")
+    if not (0 <= g.height_end < 2**64):
+        raise ValueError(f"height_end {g.height_end} not a u64")
+    if g.height_end < g.height_start:
+        raise ValueError(
+            f"height_end {g.height_end} < height_start {g.height_start}"
+        )
+    if not (0.0 <= g.w_m <= 1.0):
+        raise ValueError(f"w_m {g.w_m} not in [0, 1]")
+    if not (0.0 <= g.w_h <= 1.0):
+        raise ValueError(f"w_h {g.w_h} not in [0, 1]")
+    for i, s in enumerate(g.schemas):
+        if len(s) != ADDR_LEN:
+            raise ValueError(
+                f"schemas[{i}] must be {ADDR_LEN} bytes, got {len(s)}"
+            )
+    for i, a in enumerate(g.actions):
+        if len(a) != ADDR_LEN:
+            raise ValueError(
+                f"actions[{i}] must be {ADDR_LEN} bytes, got {len(a)}"
+            )
+
+
+# ----------------------------------------------------------------------------
+# Encoding
+# ----------------------------------------------------------------------------
+
+
+def encode_grant_spec(g: GrantSpec) -> bytes:
+    """Serialize a :class:`GrantSpec` to canonical v1 bytes.
+
+    The output is the byte-exact representation that the chain hashes
+    when computing the grant's signing-payload (paper §3.4: signature is
+    over the canonical encoding of the tuple excluding the signature
+    itself).
+
+    Determinism guarantees:
+
+    - Same input ``GrantSpec`` produces same output bytes
+    - Schema and action sets are sorted ascending before encoding,
+      regardless of input order
+    - All numeric fields use big-endian byte order
+    - Weights are converted to fixed-point with 10^4 scale (banker's-rounded)
+
+    Parameters
+    ----------
+    g
+        The grant tuple to encode.
+
+    Returns
+    -------
+    bytes
+        Canonical v1 encoding. Length is ``MIN_ENCODED_LEN + 32 *
+        (|schemas| + |actions|)``.
+
+    Notes
+    -----
+    The encoding is **stable across implementations**: any Rust or
+    TypeScript implementation following the §3.4 specification should
+    produce byte-identical output. Test vectors at
+    ``test_vectors/grant_encoding.json`` enable cross-language
+    conformance testing.
+    """
+    parts: list[bytes] = []
+
+    parts.append(bytes([VERSION_TAG]))
+    parts.append(g.master_addr)
+    parts.append(g.hot_addr)
+    parts.append(g.nonce.to_bytes(SIZE_U64, "big"))
+    parts.append(g.height_start.to_bytes(SIZE_U64, "big"))
+    parts.append(g.height_end.to_bytes(SIZE_U64, "big"))
+    parts.append(bytes([g.rule.value]))
+    parts.append(_encode_weight(g.w_m))
+    parts.append(_encode_weight(g.w_h))
+
+    # Sort schemas + actions ascending for determinism.
+    schemas_sorted = sorted(g.schemas)
+    actions_sorted = sorted(g.actions)
+
+    parts.append(len(schemas_sorted).to_bytes(SIZE_U32, "big"))
+    parts.extend(schemas_sorted)
+
+    parts.append(len(actions_sorted).to_bytes(SIZE_U32, "big"))
+    parts.extend(actions_sorted)
+
+    return b"".join(parts)
+
+
+def _encode_weight(w: float) -> bytes:
+    """Convert a [0, 1] float to u32 BE fixed-point with 10^4 scale.
+
+    Uses banker's rounding (round-half-to-even) for IEEE 754 nuisance
+    inputs. The maximum representable weight is 1.0 (10000 in the
+    encoding), the minimum is 0.0 (0). Values strictly between 0 and 1
+    are quantized to 10^-4 granularity.
+    """
+    scaled = round(w * WEIGHT_SCALE)
+    if scaled < 0 or scaled > WEIGHT_SCALE:
+        raise ValueError(f"weight {w} out of encodable range after rounding")
+    return scaled.to_bytes(SIZE_U32, "big")
+
+
+# ----------------------------------------------------------------------------
+# Decoding
+# ----------------------------------------------------------------------------
+
+
+def decode_grant_spec(b: bytes) -> GrantSpec:
+    """Deserialize canonical v1 bytes back to a :class:`GrantSpec`.
+
+    Verifies the version tag, lengths, and bound constraints. Returns
+    the reconstructed grant; raises :class:`ValueError` on any encoding
+    violation.
+
+    The decode is **lossless under quantization**: encode then decode
+    returns a GrantSpec whose ``w_m`` and ``w_h`` match the original to
+    10^-4 precision (the fixed-point scale).
+
+    Parameters
+    ----------
+    b
+        Canonical v1 bytes.
+
+    Returns
+    -------
+    GrantSpec
+        The reconstructed grant.
+
+    Raises
+    ------
+    ValueError
+        On version mismatch, length underflow, or post-decode bound
+        violation.
+    """
+    if len(b) < MIN_ENCODED_LEN:
+        raise ValueError(
+            f"encoded grant too short: got {len(b)} bytes, "
+            f"need at least {MIN_ENCODED_LEN}"
+        )
+
+    cursor = 0
+
+    version = b[cursor]
+    cursor += SIZE_VERSION
+    if version != VERSION_TAG:
+        raise ValueError(
+            f"unsupported encoding version {version:#x}; this codec is v1 "
+            f"(tag {VERSION_TAG:#x})"
+        )
+
+    master_addr = b[cursor : cursor + SIZE_ADDR]
+    cursor += SIZE_ADDR
+
+    hot_addr = b[cursor : cursor + SIZE_ADDR]
+    cursor += SIZE_ADDR
+
+    nonce = int.from_bytes(b[cursor : cursor + SIZE_U64], "big")
+    cursor += SIZE_U64
+
+    height_start = int.from_bytes(b[cursor : cursor + SIZE_U64], "big")
+    cursor += SIZE_U64
+
+    height_end = int.from_bytes(b[cursor : cursor + SIZE_U64], "big")
+    cursor += SIZE_U64
+
+    rule_byte = b[cursor]
+    cursor += SIZE_RULE_TAG
+    try:
+        rule = RuleTag(rule_byte)
+    except ValueError as exc:
+        raise ValueError(f"unknown rule tag {rule_byte:#x}") from exc
+
+    w_m = _decode_weight(b[cursor : cursor + SIZE_U32])
+    cursor += SIZE_U32
+
+    w_h = _decode_weight(b[cursor : cursor + SIZE_U32])
+    cursor += SIZE_U32
+
+    schemas_len = int.from_bytes(b[cursor : cursor + SIZE_U32], "big")
+    cursor += SIZE_U32
+
+    expected_schemas_bytes = schemas_len * SIZE_ADDR
+    if cursor + expected_schemas_bytes > len(b):
+        raise ValueError(
+            f"schemas_len={schemas_len} requires {expected_schemas_bytes} more "
+            f"bytes, have {len(b) - cursor}"
+        )
+    schemas: list[bytes] = []
+    for _ in range(schemas_len):
+        schemas.append(b[cursor : cursor + SIZE_ADDR])
+        cursor += SIZE_ADDR
+
+    if cursor + SIZE_U32 > len(b):
+        raise ValueError("truncated before actions_len")
+
+    actions_len = int.from_bytes(b[cursor : cursor + SIZE_U32], "big")
+    cursor += SIZE_U32
+
+    expected_actions_bytes = actions_len * SIZE_ADDR
+    if cursor + expected_actions_bytes != len(b):
+        raise ValueError(
+            f"actions_len={actions_len} produces {cursor + expected_actions_bytes} "
+            f"total bytes, encoded length is {len(b)}"
+        )
+    actions: list[bytes] = []
+    for _ in range(actions_len):
+        actions.append(b[cursor : cursor + SIZE_ADDR])
+        cursor += SIZE_ADDR
+
+    # Per the encoding spec, schemas + actions are sorted ascending.
+    # If the input bytes violated this (e.g., a non-conformant encoder),
+    # we surface it explicitly rather than silently accept.
+    if list(schemas) != sorted(schemas):
+        raise ValueError("schemas in encoded payload are not sorted ascending")
+    if list(actions) != sorted(actions):
+        raise ValueError("actions in encoded payload are not sorted ascending")
+
+    return GrantSpec(
+        master_addr=master_addr,
+        hot_addr=hot_addr,
+        nonce=nonce,
+        height_start=height_start,
+        height_end=height_end,
+        rule=rule,
+        w_m=w_m,
+        w_h=w_h,
+        schemas=tuple(schemas),
+        actions=tuple(actions),
+    )
+
+
+def _decode_weight(four_bytes: bytes) -> float:
+    """Convert u32 BE fixed-point weight back to a [0, 1] float."""
+    scaled = int.from_bytes(four_bytes, "big")
+    if scaled > WEIGHT_SCALE:
+        raise ValueError(
+            f"encoded weight {scaled} exceeds maximum {WEIGHT_SCALE}"
+        )
+    return scaled / WEIGHT_SCALE

--- a/prototypes/native-delegation-sim/test_vectors/README.md
+++ b/prototypes/native-delegation-sim/test_vectors/README.md
@@ -1,0 +1,50 @@
+# Cross-language test vectors for native-delegation-sim
+
+Each JSON file in this directory encodes a deterministic test case for one of the formulas / encodings in the native-delegation v0.2 paper. Any implementation in any language (Rust, TypeScript, Go) can load these vectors and verify that its implementation produces the same output to fixed precision (or byte-exact for binary encodings).
+
+## File index
+
+| File | Paper section | What it tests | Encoding |
+|---|---|---|---|
+| `grant_encoding.json` | §3.4 + Appendix B | Single-block canonical grant encoding | Byte-exact, hex |
+
+## Vector format
+
+Each vector is:
+
+```json
+{
+  "name": "...",
+  "section": "§3.4",
+  "input": { ... },
+  "expected": {
+    "encoded_hex": "...",
+    "encoded_length": ...
+  },
+  "tolerance": 1e-12
+}
+```
+
+Tolerance is `1e-12` for floating-point fields. The `encoded_hex` field is byte-exact: any conforming implementation must produce exactly the same bytes.
+
+## Regenerating vectors
+
+```bash
+cd prototypes/native-delegation-sim
+source .venv/bin/activate
+python scripts/regenerate_test_vectors.py
+```
+
+This regenerates every vector file from the Python reference implementation, ensuring the vectors are always in sync with the simulator's behavior.
+
+## Cross-language conformance
+
+A future Rust or TypeScript implementation of the §3.4 canonical grant encoding should follow these steps to verify conformance:
+
+1. Implement encoding per the layout in `src/native_delegation_sim/encoding.py` (top docstring).
+2. Load each vector's `input` fields, construct the grant tuple.
+3. Encode to bytes.
+4. Compare the encoded bytes to `expected.encoded_hex` (after hex-decode).
+5. All vectors must match byte-exactly.
+
+If any vector fails, either the reference Python implementation has drifted from the spec, or the implementation under test deviates from the encoding rules. The Python reference is canonical; deviations on the implementer side need fixing.

--- a/prototypes/native-delegation-sim/test_vectors/grant_encoding.json
+++ b/prototypes/native-delegation-sim/test_vectors/grant_encoding.json
@@ -1,0 +1,142 @@
+{
+  "version": "0.3.0",
+  "vectors": [
+    {
+      "name": "minimal_grant_master_only",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "hot_addr": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "nonce": 0,
+        "height_start": 0,
+        "height_end": 0,
+        "rule": "MASTER_ONLY",
+        "w_m": 1.0,
+        "w_h": 0.0,
+        "schemas": [],
+        "actions": []
+      },
+      "expected": {
+        "encoded_hex": "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002710000000000000000000000000",
+        "encoded_length": 106
+      },
+      "tolerance": 1e-12
+    },
+    {
+      "name": "recommended_calibration",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hot_addr": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "nonce": 42,
+        "height_start": 1000,
+        "height_end": 10000,
+        "rule": "BOTH_SLASHED",
+        "w_m": 0.7,
+        "w_h": 0.3,
+        "schemas": [
+          "0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
+        ],
+        "actions": [
+          "0x4242424242424242424242424242424242424242424242424242424242424242"
+        ]
+      },
+      "expected": {
+        "encoded_hex": "01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb000000000000002a00000000000003e800000000000027100200001b5800000bb8000000010f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f000000014242424242424242424242424242424242424242424242424242424242424242",
+        "encoded_length": 170
+      },
+      "tolerance": 1e-12
+    },
+    {
+      "name": "hot_only_rule",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "hot_addr": "0x2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce": 1,
+        "height_start": 100,
+        "height_end": 200,
+        "rule": "HOT_ONLY",
+        "w_m": 0.0,
+        "w_h": 1.0,
+        "schemas": [],
+        "actions": []
+      },
+      "expected": {
+        "encoded_hex": "01111111111111111111111111111111111111111111111111111111111111111122222222222222222222222222222222222222222222222222222222222222220000000000000001000000000000006400000000000000c80100000000000027100000000000000000",
+        "encoded_length": 106
+      },
+      "tolerance": 1e-12
+    },
+    {
+      "name": "multi_schema_unsorted_input",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0x3333333333333333333333333333333333333333333333333333333333333333",
+        "hot_addr": "0x4444444444444444444444444444444444444444444444444444444444444444",
+        "nonce": 7,
+        "height_start": 500,
+        "height_end": 1500,
+        "rule": "BOTH_SLASHED",
+        "w_m": 0.6,
+        "w_h": 0.4,
+        "schemas": [
+          "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "actions": [
+          "0x9999999999999999999999999999999999999999999999999999999999999999",
+          "0x1111111111111111111111111111111111111111111111111111111111111111"
+        ]
+      },
+      "expected": {
+        "encoded_hex": "0133333333333333333333333333333333333333333333333333333333333333334444444444444444444444444444444444444444444444444444444444444444000000000000000700000000000001f400000000000005dc020000177000000fa000000003aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc0000000211111111111111111111111111111111111111111111111111111111111111119999999999999999999999999999999999999999999999999999999999999999",
+        "encoded_length": 266
+      },
+      "tolerance": 1e-12
+    },
+    {
+      "name": "max_u64_boundary",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "hot_addr": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "nonce": 18446744073709551615,
+        "height_start": 18446744073709551614,
+        "height_end": 18446744073709551615,
+        "rule": "BOTH_SLASHED",
+        "w_m": 0.5,
+        "w_h": 0.5,
+        "schemas": [],
+        "actions": []
+      },
+      "expected": {
+        "encoded_hex": "01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffffffeffffffffffffffff0200001388000013880000000000000000",
+        "encoded_length": 106
+      },
+      "tolerance": 1e-12
+    },
+    {
+      "name": "weight_min_granularity",
+      "section": "\u00a73.4 + Appendix B",
+      "input": {
+        "master_addr": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "hot_addr": "0x0101010101010101010101010101010101010101010101010101010101010101",
+        "nonce": 1,
+        "height_start": 0,
+        "height_end": 1,
+        "rule": "BOTH_SLASHED",
+        "w_m": 0.9999,
+        "w_h": 0.0001,
+        "schemas": [],
+        "actions": []
+      },
+      "expected": {
+        "encoded_hex": "0100000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101010101010101010101010101000000000000000100000000000000000000000000000001020000270f000000010000000000000000",
+        "encoded_length": 106
+      },
+      "tolerance": 1e-12
+    }
+  ]
+}

--- a/prototypes/native-delegation-sim/tests/test_encoding.py
+++ b/prototypes/native-delegation-sim/tests/test_encoding.py
@@ -1,0 +1,333 @@
+"""Tests for the §3.4 + Appendix B canonical grant encoding (M3).
+
+Four test classes:
+
+- ``TestGrantSpec`` covers the §3.4 tuple's bound checks: 32-byte
+  addresses, u64 nonces and heights, weights in [0, 1].
+- ``TestEncodeGrantSpec`` covers encode() deterministic output:
+  fixed-width fields are big-endian, schemas/actions are sorted before
+  encoding, byte length is what the spec says.
+- ``TestDecodeGrantSpec`` covers decode() correctness, including
+  roundtrip and explicit rejection of malformed inputs.
+- ``TestCrossLanguageConformance`` is the headline test: stable
+  byte-level output for canonical input cases. These are the values
+  that a future Rust / TypeScript implementation should match exactly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from native_delegation_sim import (
+    GrantSpec,
+    RuleTag,
+    decode_grant_spec,
+    encode_grant_spec,
+)
+from native_delegation_sim.encoding import MIN_ENCODED_LEN, VERSION_TAG, WEIGHT_SCALE
+
+
+# Canonical 32-byte fixtures used across tests.
+ZERO_ADDR = b"\x00" * 32
+ONE_ADDR = b"\x01" * 32
+TWO_ADDR = b"\x02" * 32
+SCHEMA_A = b"\xAA" * 32
+SCHEMA_B = b"\xBB" * 32
+ACTION_X = b"\x0F" * 32
+
+
+def _basic_spec(**overrides) -> GrantSpec:
+    """Construct a minimal valid GrantSpec, with overrides."""
+    defaults = {
+        "master_addr": ZERO_ADDR,
+        "hot_addr": ONE_ADDR,
+        "nonce": 1,
+        "height_start": 100,
+        "height_end": 200,
+        "rule": RuleTag.BOTH_SLASHED,
+        "w_m": 0.7,
+        "w_h": 0.3,
+        "schemas": (),
+        "actions": (),
+    }
+    defaults.update(overrides)
+    return GrantSpec(**defaults)
+
+
+class TestGrantSpec:
+    """§3.4 tuple bound checks."""
+
+    def test_basic_construct(self) -> None:
+        g = _basic_spec()
+        assert g.master_addr == ZERO_ADDR
+        assert g.nonce == 1
+        assert g.rule == RuleTag.BOTH_SLASHED
+
+    def test_short_master_addr_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"master_addr"):
+            _basic_spec(master_addr=b"\x00" * 16)
+
+    def test_short_hot_addr_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"hot_addr"):
+            _basic_spec(hot_addr=b"\x00" * 16)
+
+    def test_height_end_before_start_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"height_end"):
+            _basic_spec(height_start=200, height_end=100)
+
+    def test_negative_nonce_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"nonce"):
+            _basic_spec(nonce=-1)
+
+    def test_w_m_above_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"w_m"):
+            _basic_spec(w_m=1.5)
+
+    def test_w_h_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"w_h"):
+            _basic_spec(w_h=-0.1)
+
+    def test_short_schema_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"schemas"):
+            _basic_spec(schemas=(b"\xAA" * 16,))
+
+    def test_short_action_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"actions"):
+            _basic_spec(actions=(b"\x0F" * 31,))
+
+    def test_immutability(self) -> None:
+        """GrantSpec is frozen."""
+        g = _basic_spec()
+        with pytest.raises(Exception):
+            g.nonce = 99  # type: ignore[misc]
+
+
+class TestEncodeGrantSpec:
+    """encode() determinism and structural correctness."""
+
+    def test_minimum_length_no_scope(self) -> None:
+        g = _basic_spec()
+        b = encode_grant_spec(g)
+        assert len(b) == MIN_ENCODED_LEN
+
+    def test_length_with_schemas(self) -> None:
+        g = _basic_spec(schemas=(SCHEMA_A, SCHEMA_B))
+        b = encode_grant_spec(g)
+        # 2 schemas, each 32B, plus base.
+        assert len(b) == MIN_ENCODED_LEN + 64
+
+    def test_length_with_schemas_and_actions(self) -> None:
+        g = _basic_spec(schemas=(SCHEMA_A,), actions=(ACTION_X,))
+        b = encode_grant_spec(g)
+        assert len(b) == MIN_ENCODED_LEN + 32 + 32
+
+    def test_version_tag_first_byte(self) -> None:
+        b = encode_grant_spec(_basic_spec())
+        assert b[0] == VERSION_TAG
+
+    def test_master_then_hot_addr(self) -> None:
+        g = _basic_spec(master_addr=ZERO_ADDR, hot_addr=ONE_ADDR)
+        b = encode_grant_spec(g)
+        assert b[1:33] == ZERO_ADDR
+        assert b[33:65] == ONE_ADDR
+
+    def test_nonce_big_endian(self) -> None:
+        g = _basic_spec(nonce=0x0102030405060708)
+        b = encode_grant_spec(g)
+        assert b[65:73] == bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+
+    def test_heights_big_endian(self) -> None:
+        g = _basic_spec(height_start=100, height_end=200)
+        b = encode_grant_spec(g)
+        assert b[73:81] == (100).to_bytes(8, "big")
+        assert b[81:89] == (200).to_bytes(8, "big")
+
+    def test_rule_tag_byte(self) -> None:
+        for rule_tag in (RuleTag.MASTER_ONLY, RuleTag.HOT_ONLY, RuleTag.BOTH_SLASHED):
+            b = encode_grant_spec(_basic_spec(rule=rule_tag))
+            assert b[89] == rule_tag.value
+
+    def test_weights_fixed_point(self) -> None:
+        g = _basic_spec(w_m=0.7, w_h=0.3)
+        b = encode_grant_spec(g)
+        assert b[90:94] == (7000).to_bytes(4, "big")
+        assert b[94:98] == (3000).to_bytes(4, "big")
+
+    def test_weight_zero_at_boundary(self) -> None:
+        g = _basic_spec(rule=RuleTag.HOT_ONLY, w_m=0.0, w_h=1.0)
+        b = encode_grant_spec(g)
+        assert b[90:94] == (0).to_bytes(4, "big")
+        assert b[94:98] == (WEIGHT_SCALE).to_bytes(4, "big")
+
+    def test_schemas_sorted_ascending(self) -> None:
+        """Encoder sorts schemas regardless of input order."""
+        b1 = encode_grant_spec(_basic_spec(schemas=(SCHEMA_A, SCHEMA_B)))
+        b2 = encode_grant_spec(_basic_spec(schemas=(SCHEMA_B, SCHEMA_A)))
+        assert b1 == b2  # determinism: order doesn't matter
+
+    def test_actions_sorted_ascending(self) -> None:
+        b1 = encode_grant_spec(_basic_spec(actions=(ACTION_X, b"\x10" * 32)))
+        b2 = encode_grant_spec(_basic_spec(actions=(b"\x10" * 32, ACTION_X)))
+        assert b1 == b2
+
+    def test_determinism_under_same_input(self) -> None:
+        """Same GrantSpec produces bit-identical output on repeated encode."""
+        g = _basic_spec(schemas=(SCHEMA_A, SCHEMA_B), actions=(ACTION_X,))
+        b1 = encode_grant_spec(g)
+        b2 = encode_grant_spec(g)
+        assert b1 == b2
+
+
+class TestDecodeGrantSpec:
+    """decode() correctness, roundtrips, and rejection of malformed inputs."""
+
+    def test_roundtrip_minimal(self) -> None:
+        g = _basic_spec()
+        decoded = decode_grant_spec(encode_grant_spec(g))
+        assert decoded == g
+
+    def test_roundtrip_with_scope(self) -> None:
+        g = _basic_spec(
+            schemas=(SCHEMA_A, SCHEMA_B),
+            actions=(ACTION_X, b"\x42" * 32),
+        )
+        decoded = decode_grant_spec(encode_grant_spec(g))
+        assert decoded == g
+
+    def test_roundtrip_weight_quantization(self) -> None:
+        """Decode quantizes to 10^-4 grid; encode + decode is fixed-point stable."""
+        g = _basic_spec(w_m=0.7500, w_h=0.2500)
+        decoded = decode_grant_spec(encode_grant_spec(g))
+        assert decoded.w_m == pytest.approx(0.7500)
+        assert decoded.w_h == pytest.approx(0.2500)
+
+    def test_truncated_input_rejected(self) -> None:
+        b = encode_grant_spec(_basic_spec())
+        with pytest.raises(ValueError, match=r"too short"):
+            decode_grant_spec(b[:50])
+
+    def test_wrong_version_rejected(self) -> None:
+        b = encode_grant_spec(_basic_spec())
+        bad = bytes([0xFF]) + b[1:]
+        with pytest.raises(ValueError, match=r"unsupported encoding version"):
+            decode_grant_spec(bad)
+
+    def test_unknown_rule_tag_rejected(self) -> None:
+        b = encode_grant_spec(_basic_spec())
+        # Replace rule byte at offset 89 with an invalid value.
+        bad = b[:89] + bytes([0xFE]) + b[90:]
+        with pytest.raises(ValueError, match=r"rule tag"):
+            decode_grant_spec(bad)
+
+    def test_truncated_after_schemas_len_rejected(self) -> None:
+        # Construct a payload claiming 5 schemas but cut off the bytes.
+        g = _basic_spec()
+        b = encode_grant_spec(g)
+        # b ends after actions_len=0. Replace schemas_len with 5.
+        # Offset of schemas_len: MIN_ENCODED_LEN - SIZE_U32 - SIZE_U32 = 98
+        bad = b[:98] + (5).to_bytes(4, "big") + b[102:]
+        with pytest.raises(ValueError, match=r"schemas_len"):
+            decode_grant_spec(bad)
+
+    def test_unsorted_schemas_rejected(self) -> None:
+        """A non-conformant encoder that wrote schemas out of order is rejected."""
+        # Manually construct an encoding with schemas in descending order.
+        g = _basic_spec()
+        b = encode_grant_spec(g)
+        # Replace schemas_len + 0-byte (empty) with 2 + (B, A) order.
+        prefix = b[:98]
+        # schemas_len = 2, then B, then A (out of order).
+        bad_middle = (2).to_bytes(4, "big") + SCHEMA_B + SCHEMA_A
+        actions_part = (0).to_bytes(4, "big")
+        bad = prefix + bad_middle + actions_part
+        with pytest.raises(ValueError, match=r"schemas.*sorted"):
+            decode_grant_spec(bad)
+
+    def test_unsorted_actions_rejected(self) -> None:
+        g = _basic_spec()
+        b = encode_grant_spec(g)
+        prefix = b[:98]
+        schemas_part = (0).to_bytes(4, "big")
+        action_a = b"\x01" * 32
+        action_b = b"\x02" * 32
+        bad_actions = (2).to_bytes(4, "big") + action_b + action_a
+        bad = prefix + schemas_part + bad_actions
+        with pytest.raises(ValueError, match=r"actions.*sorted"):
+            decode_grant_spec(bad)
+
+
+class TestCrossLanguageConformance:
+    """Byte-exact outputs for canonical input cases.
+
+    These are the values that a future Rust or TypeScript implementation
+    of the §3.4 encoding must match. If these tests fail, either this
+    Python reference has drifted or the spec has changed; in either case
+    the cross-language test_vectors/grant_encoding.json must be
+    regenerated.
+    """
+
+    def test_minimal_grant_byte_exact(self) -> None:
+        """Minimal grant: all-zero addrs, nonce=0, both heights=0, MASTER_ONLY."""
+        g = GrantSpec(
+            master_addr=b"\x00" * 32,
+            hot_addr=b"\x00" * 32,
+            nonce=0,
+            height_start=0,
+            height_end=0,
+            rule=RuleTag.MASTER_ONLY,
+            w_m=1.0,
+            w_h=0.0,
+        )
+        b = encode_grant_spec(g)
+        expected_hex = (
+            "01"  # version tag
+            + "00" * 32  # master_addr
+            + "00" * 32  # hot_addr
+            + "00" * 8  # nonce
+            + "00" * 8  # height_start
+            + "00" * 8  # height_end
+            + "00"  # rule_tag = MASTER_ONLY
+            + "00002710"  # w_m = 10000 (= 1.0)
+            + "00000000"  # w_h = 0
+            + "00000000"  # schemas_len = 0
+            + "00000000"  # actions_len = 0
+        )
+        assert b.hex() == expected_hex
+        assert len(b) == MIN_ENCODED_LEN
+
+    def test_recommended_calibration_byte_exact(self) -> None:
+        """§5.5 recommended (w_m, w_h) = (0.7, 0.3) with reasonable params."""
+        g = GrantSpec(
+            master_addr=b"\xAA" * 32,
+            hot_addr=b"\xBB" * 32,
+            nonce=42,
+            height_start=1000,
+            height_end=10000,
+            rule=RuleTag.BOTH_SLASHED,
+            w_m=0.7,
+            w_h=0.3,
+            schemas=(SCHEMA_A,),
+            actions=(ACTION_X,),
+        )
+        b = encode_grant_spec(g)
+        # Just check stable, deterministic, and decodes back.
+        assert len(b) == MIN_ENCODED_LEN + 32 + 32
+        assert decode_grant_spec(b) == g
+
+    def test_max_supply_heights_byte_exact(self) -> None:
+        """u64 maximum heights encode without overflow."""
+        max_u64 = 2**64 - 1
+        g = GrantSpec(
+            master_addr=b"\x11" * 32,
+            hot_addr=b"\x22" * 32,
+            nonce=max_u64,
+            height_start=max_u64 - 1,
+            height_end=max_u64,
+            rule=RuleTag.BOTH_SLASHED,
+            w_m=0.5,
+            w_h=0.5,
+        )
+        b = encode_grant_spec(g)
+        # nonce field at offset 65, big-endian 0xFFFF...FF
+        assert b[65:73] == b"\xff" * 8
+        assert decode_grant_spec(b) == g

--- a/prototypes/native-delegation-sim/tests/test_scaffold.py
+++ b/prototypes/native-delegation-sim/tests/test_scaffold.py
@@ -1,11 +1,16 @@
 """Smoke test: package importable, version present, public API matches the
 current milestone scope.
 
-v0.2 (2026-05-20) bumps version to 0.2.0 and adds the M2 surface:
-lifecycle (paper §4.4) + strategy search (Monte Carlo over §5.5 with
-stochastic compromise probability). The real correctness coverage
-lives in ``test_slashing_inheritance.py`` (M1), ``test_lifecycle.py``
-(M2), and ``test_strategy_search.py`` (M2).
+v0.3 (2026-05-22) bumps version to 0.3.0 and adds the M3 surface: the
+§3.4 + Appendix B canonical grant encoding (``GrantSpec``,
+``encode_grant_spec``, ``decode_grant_spec``) for cross-language
+conformance. The real correctness coverage lives in
+``test_encoding.py``.
+
+v0.2 (2026-05-20) added the M2 surface: lifecycle (paper §4.4) +
+strategy search (Monte Carlo over §5.5 with stochastic compromise
+probability). v0.1 (M1) shipped the deterministic grid sweep + the
+four-property predicates.
 """
 
 from __future__ import annotations
@@ -14,11 +19,11 @@ from __future__ import annotations
 def test_package_imports():
     import native_delegation_sim
 
-    assert native_delegation_sim.__version__ == "0.2.0"
+    assert native_delegation_sim.__version__ == "0.3.0"
 
 
-def test_public_api_matches_m2_scope():
-    """v0.2 (M2) extends the M1 surface with lifecycle + strategy search."""
+def test_public_api_matches_m3_scope():
+    """v0.3 (M3) extends the M2 surface with canonical grant encoding."""
     import native_delegation_sim
 
     expected = {
@@ -42,5 +47,10 @@ def test_public_api_matches_m2_scope():
         "SearchResults",
         "StochasticAdversary",
         "run_strategy_search",
+        # M3
+        "GrantSpec",
+        "RuleTag",
+        "encode_grant_spec",
+        "decode_grant_spec",
     }
     assert set(native_delegation_sim.__all__) == expected


### PR DESCRIPTION
Closes the M3 milestone in native-delegation-sim. Adds the byte-exact §3.4 + Appendix B canonical grant encoding so that future Rust / TypeScript implementations of Ligate Chain can produce identical bytes for the same logical grant.

**What ships:**
- `GrantSpec` dataclass with the full §3.4 tuple (10 fields) and all protocol-level bound checks (32B addresses, u64 nonce/heights, weights in [0, 1], 32B schema/action ids)
- `encode_grant_spec()`: deterministic v1 encoding with version tag, big-endian numeric fields, 10^-4 fixed-point weights, ascending-sorted schemas/actions
- `decode_grant_spec()`: roundtrip with bound-check enforcement; rejects unsorted scope lists, wrong version, truncated input, unknown rule tags
- 35 new tests across 4 test classes (TestGrantSpec, TestEncodeGrantSpec, TestDecodeGrantSpec, TestCrossLanguageConformance)
- 6 canonical test vectors in `test_vectors/grant_encoding.json` with byte-exact `encoded_hex` outputs (minimal grant, recommended §5.5 calibration, hot-only rule, multi-schema with unsorted input, max u64 boundary, weight quantization edge case)
- `scripts/regenerate_test_vectors.py` rebuilds vectors from the Python reference

**Verification:**
- 91/91 tests passing (was 56 at M2)
- `scripts/check_citations.py`: 31 paper files, 96 citations OK
- Package version bumped to 0.3.0

**Cross-language conformance flow** (documented in test_vectors/README.md): a Rust or TypeScript implementation loads each vector, encodes its input, hex-encodes the bytes, compares to `expected.encoded_hex`. All vectors must match byte-exactly.

Tracks issue #41 (native-delegation v0.2 substantive draft). M3 is the empirical-discipline completion for the paper's §3.4 encoding spec.