### PR TITLE
chore(cla): allowlist proofmancer (current code-owner login)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,4 +29,7 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/ligate-io/ligate-research/blob/main/CLA.md'
           branch: 'cla/signatures'
-          allowlist: 'sstefdev,dependabot[bot],*[bot]'
+          # Code-owner allowlist + bot allowlist. proofmancer is the
+          # primary code-owner login (Stefan Stefanović). sstefdev is
+          # kept for any older PRs authored under the legacy username.
+          allowlist: 'proofmancer,sstefdev,dependabot[bot],*[bot]'


### PR DESCRIPTION
Every PR since 2026-05-23 has had CLAAssistant fail because the allowlist had only `sstefdev` (legacy username); the actual PR author login is `proofmancer` (`Stefan Stefanović`, code-owner). Admin-merge worked around it but the red check was noise.

**Fix**: add `proofmancer` to the allowlist alongside `sstefdev` (keeping the legacy entry for any older PRs that might still be open).

**Result**: future PRs from `proofmancer` show CLAAssistant green instead of red.

**Verify after merge**: open a no-op PR (or watch the next real PR) and confirm both checks (`check-citations` + `CLAAssistant`) report pass.