### PR TITLE
poua: arXiv ID 2605.25844 + BibTeX + paper-list refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ This repository is the upstream of the technical claims our marketing surface (l
 
 | Paper | Status | Latest version | Topic |
 |---|---|---|---|
-| [Proof of Useful Attestation (PoUA)](papers/poua/) | Working draft | v0.7.2 (2026-05-03) | Consensus weighting primitive that aligns validator influence with the production of valid attestation work |
-| [Per-Schema Fee Markets](papers/per-schema-fees/) | Outline | v0.1 (2026-05-02) | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
-
-Future papers planned (filed as issues in this repo):
-
-- Per-schema fee markets (EIP-1559-style demand curves per attestation schema)
-- Native delegation primitives (hot-key / master-key separation as a runtime primitive, foundation for the Iris MCP relayer)
-- Cross-schema composition (typed attestation references with slashing-aware proof propagation)
-- Time-locked / commit-reveal attestations (sealed-bid auctions, embargoed press, regulatory time-locks)
+| [Proof of Useful Attestation (PoUA)](papers/poua/) | Working paper, [arXiv:2605.25844](https://arxiv.org/abs/2605.25844) | v0.9.2 (2026-05-25) | Consensus weighting primitive that aligns validator influence with valid attestation work |
+| [Native Delegation](papers/native-delegation/) | Working paper | v0.2 (2026-05-25) | Hot-key / master-key separation as a runtime primitive (Iris foundation) |
+| [Per-Schema Fee Markets](papers/per-schema-fees/) | Working paper | v0.2 (2026-05-25) | EIP-1559-style per-schema base fees with PoUA-coupled burn |
+| [Cross-Schema Composition](papers/cross-schema-composition/) | Working paper | v0.2 (2026-05-25) | Typed attestation references with slashing-aware proof propagation |
+| [Time-Locked Attestations](papers/time-locked-attestations/) | Working paper | v0.2 (2026-05-25) | Commit-reveal as a runtime primitive |
+| [Native DA Layer](papers/native-da/) | Working paper | v0.2 (2026-05-25) | A native DA layer specialized for the attestation workload (post-Celestia track) |
+| [Schema-Bound Tokens](papers/schema-bound-tokens/) | Research note | v0.2 (2026-05-25) | Attestor sets as mint authority on attestation-native chains |
+| [EAS Comparison](papers/eas-comparison/) | Outline | v0.1 (2026-05-25) | Ligate Chain vs Ethereum Attestation Service |
+| [Themisra Licensing Schemas](papers/themisra-licensing-schemas/) | Planning | v0.0 (2026-05-05) | Prompt + content licensing schemas riding on Proof of Prompt |
+| [Verifiable Content Provenance](papers/verifiable-content-provenance/) | Planning | v0.0 (2026-05-05) | Detection, embedding, and watermarking for the Ligate receipt layer |
 
 ## Reading and contributing
 

--- a/papers/poua/CHANGELOG.md
+++ b/papers/poua/CHANGELOG.md
@@ -12,6 +12,8 @@ No content changes. The author was always Stefan Stefanović; v0.9.2 just makes 
 
 Files touched: `poua.md` title page, footer line, `poua.tex` regenerated, `poua.pdf` regenerated, `poua-arxiv.tar.gz` rebuilt from updated source for re-upload.
 
+**Submitted to arXiv on 2026-05-25 as [`arXiv:2605.25844`](https://arxiv.org/abs/2605.25844) (cs.CR primary, cs.DC + cs.GT cross-lists).**
+
 ---
 
 ## v0.9.1 (2026-05-25): reviewer follow-up clarity pass + release-prep tightening

--- a/papers/poua/README.md
+++ b/papers/poua/README.md
@@ -23,8 +23,23 @@ The simulator at [`prototypes/poua-sim/`](../../prototypes/poua-sim/) produces t
 - **Working paper**: [`poua.pdf`](poua.pdf) (compiled) / [`poua.md`](poua.md) (markdown source) / [`poua.tex`](poua.tex) (LaTeX source for arXiv)
 - **Version**: v0.9.2
 - **Author**: Stefan Stefanović (Ligate Labs)
-- **Status**: Author attribution on title page (aligns PDF with arXiv metadata); v0.9.1 reviewer clarity pass + release-prep tightening carried forward; arXiv preprint in flight (cs.CR, pending endorsement)
+- **arXiv**: [`arXiv:2605.25844`](https://arxiv.org/abs/2605.25844) (cs.CR primary, cs.DC + cs.GT cross-lists; submitted 2026-05-25)
+- **Status**: Author attribution on title page (aligns PDF with arXiv metadata); v0.9.1 reviewer clarity pass + release-prep tightening carried forward; preprint listed on arXiv
 - **Date**: 2026-05-25
+
+## How to cite
+
+```bibtex
+@misc{stefanovic2026poua,
+  title         = {Proof of Useful Attestation: A Consensus Primitive for Attestation-Native Chains},
+  author        = {Stefanović, Stefan},
+  year          = {2026},
+  eprint        = {2605.25844},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CR},
+  url           = {https://arxiv.org/abs/2605.25844}
+}
+```
 
 ## Abstract
 


### PR DESCRIPTION
## Summary

PoUA v0.9.2 received its canonical arXiv identifier: **[arXiv:2605.25844](https://arxiv.org/abs/2605.25844)** (cs.CR primary, cs.DC + cs.GT cross-lists, submitted 2026-05-25).

Closes the Part-1 (repo updates) deliverable of [#124](https://github.com/ligate-io/ligate-research/issues/124). Part 2 (X announcement) tracks separately on that issue.

## What changed

- \`papers/poua/README.md\`: "Latest" section now carries the arXiv ID + URL + cross-list metadata; status line updated from "in flight" to "listed on arXiv"; new "How to cite" section with BibTeX citation block.
- \`papers/poua/CHANGELOG.md\`: v0.9.2 entry expanded with the arXiv submission confirmation line.
- \`README.md\` (root): "Current papers" table refreshed end-to-end. PoUA row updated to v0.9.2 + arXiv link. Added rows for native-delegation, cross-schema-composition, time-locked-attestations, native-da, schema-bound-tokens (all v0.2 shipped today), plus eas-comparison v0.1 (merged #138) and the two v0.0 planning-stage papers. The stale "Future papers planned" bullet list dropped (covered by the table now).

## Out of scope (per #124 Part 1)

- \`poua.md\` title-page metadata: low-priority, deferred to bundle with next substantive update
- \`poua.tex\` regeneration: same; the PDF source on arXiv carries the canonical metadata via the arXiv listing, not the embedded TeX
- Part 2 X announcement: tracks separately

## Test plan

- [ ] \`scripts/check_citations.py\` passes
- [ ] No em dashes (verified locally)
- [ ] arXiv link resolves