### PR TITLE
chore(readme): refresh narrative text + papers/README.md index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ligate Research
 
-Public research artifacts from Ligate Labs: working papers, formal specifications, and reference simulators for protocol primitives that ship in [Ligate Chain](https://github.com/ligate-io/ligate-chain) and adjacent projects.
+Public research artifacts from Ligate Labs: working papers and reference simulators for the protocol primitives that ship in [Ligate Chain](https://github.com/ligate-io/ligate-chain) and adjacent projects. Fifteen papers across consensus, delegation, per-schema fee markets, typed attestation composition, time-locks, native data availability, schema-bound tokens, cross-chain portability, AVOW tokenomics, and four comparison or integration notes (EAS, C2PA, TEE, post-quantum migration), plus two Themisra-specific schema papers. Three Python simulators (PoUA, native delegation, per-schema fees) empirically validate the headline claims. The foundation paper, [Proof of Useful Attestation](papers/poua/), is on arXiv at [2605.25844](https://arxiv.org/abs/2605.25844).
 
-This repository is the upstream of the technical claims our marketing surface (ligate.io, ligate.io/docs) makes. If a claim about consensus, fee markets, attestation composition, delegation, or any other protocol-level design decision appears on the marketing site, the corresponding paper or spec lives here.
+This repository is the upstream of the technical claims our marketing surface ([ligate.io](https://ligate.io), [docs.ligate.io](https://docs.ligate.io)) makes. If a claim about consensus, fee markets, attestation composition, delegation, or any other protocol-level design decision appears on the marketing site, the corresponding paper lives here.
 
 ![Four-panel portfolio overview: PoUA cost-to-attack and realized κ lifecycle (top), native-delegation §5.5 satisfying region and per-schema-fees KL-detector ROC (bottom)](figures/portfolio-overview.png)
 
@@ -10,15 +10,17 @@ This repository is the upstream of the technical claims our marketing surface (l
 
 ## What's in scope
 
-- **Working papers**: design documents for novel protocol primitives, written at a level appropriate for academic and engineering review (`papers/`)
-- **Reference simulators**: Python prototypes that exercise the mechanisms papers describe, used for parameter calibration and empirical validation of paper claims (`prototypes/`)
-- **Specification drafts**: formalized specifications that bridge papers and the engineering RFCs in `ligate-chain/docs/protocol/rfcs/` (in `papers/` alongside the corresponding paper)
+- **Working papers** (`papers/`): design documents for novel protocol primitives, written at a level appropriate for academic and engineering review. Each paper carries its own README with version history and an annotated quick-read summary.
+- **Reference simulators** (`prototypes/`): Python prototypes that exercise the mechanisms papers describe, used for parameter calibration and empirical validation of paper claims. Every load-bearing numerical claim in a published paper should resolve to a simulator test or test vector; see [`papers/README.md`](papers/README.md) for the discipline.
+- **Cross-paper consistency** ([`papers/CONSISTENCY_REVIEW.md`](papers/CONSISTENCY_REVIEW.md)): running ledger of where two papers touch the same primitive and which one is authoritative.
+
+The engineering RFCs in `ligate-chain/docs/protocol/rfcs/` consume the papers here; this repo holds the research, the chain repo holds the protocol-level normative spec.
 
 ## What's NOT in scope
 
-- Production code (lives in `ligate-chain`)
-- Marketing copy or vision documents (live in `ligate-marketing`, public via ligate.io)
-- Engineering tickets (filed in the relevant repo's GitHub issues)
+- Production code (lives in [`ligate-chain`](https://github.com/ligate-io/ligate-chain))
+- Marketing copy and vision documents (live in `ligate-marketing`, public via [ligate.io](https://ligate.io))
+- Engineering tickets (filed in the relevant repo's GitHub issues; cross-repo umbrellas live in `ligate-marketing`)
 
 ## Current papers
 
@@ -42,7 +44,9 @@ This repository is the upstream of the technical claims our marketing surface (l
 
 ## Reading and contributing
 
-These are working papers. They are public so that external review, critique, and collaboration are possible, not because they are finished. Each paper carries an explicit version history and a `STATUS` line in its title block. Drafts are marked as such; do not cite a v0.x paper as a finished result.
+These are working papers. They are public so that external review, critique, and collaboration are possible, not because they are finished. Each paper carries an explicit version history and a status line in its title block. Drafts are marked as such; do not cite a v0.x paper as a finished result. If you do cite, cite the version explicitly (e.g., "PoUA v0.9.2") so it is unambiguous which revision the claim relies on.
+
+If you don't know where to start, the foundation paper is [PoUA](papers/poua/) ([arXiv:2605.25844](https://arxiv.org/abs/2605.25844)). The other papers either consume PoUA's primitives ([per-schema-fees](papers/per-schema-fees/), [cross-schema-composition](papers/cross-schema-composition/), [schema-bound-tokens](papers/schema-bound-tokens/)) or specify the runtime layer that sits on top of it ([native-delegation](papers/native-delegation/), [time-locked-attestations](papers/time-locked-attestations/), [native-da](papers/native-da/)). The remaining notes are economics ([tokenomics](papers/tokenomics/)), portability ([cross-chain-portability](papers/cross-chain-portability/)), comparisons ([eas-comparison](papers/eas-comparison/), [c2pa-composition](papers/c2pa-composition/), [tee-composition](papers/tee-composition/)), migration plans ([pq-migration](papers/pq-migration/)), and Themisra schema work ([themisra-licensing-schemas](papers/themisra-licensing-schemas/), [verifiable-content-provenance](papers/verifiable-content-provenance/)).
 
 Issues and pull requests are welcome:
 
@@ -50,7 +54,7 @@ Issues and pull requests are welcome:
 - For typos or small wording fixes, send a PR directly
 - For larger structural revisions, open an issue first to discuss
 
-We do not expect external contributors to author full papers in this repo at this stage. Once the research direction stabilizes (mid-2026 onward), we anticipate opening up authorship more broadly.
+All pull requests trigger a Contributor License Agreement check. The CLA terms are in [`CLA.md`](CLA.md); the assistant bot will prompt you to sign inline on your first PR. We do not expect external contributors to author full papers in this repo at the current stage; that surface opens up as the research direction stabilizes.
 
 ## License
 

--- a/papers/README.md
+++ b/papers/README.md
@@ -8,24 +8,42 @@ The canonical sequence per the marketing-side umbrella tracker (ligate-marketing
 
 | Paper | Latest | Status | Topic |
 |---|---|---|---|
-| [PoUA, Proof of Useful Attestation](poua/) | v0.8 (2026-05-19) | Draft, arXiv submission pending endorser | Consensus weighting primitive aligning validator influence with valid attestation work. Reviewer-feedback consolidation + M1-M7 simulator integration of v0.7.2. |
-| [Per-Schema Fee Markets](per-schema-fees/) | v0.1.1 (2026-05-04) | Outline + §4 substantive | EIP-1559-style demand curves per attestation schema, with sponsored-gas integration |
-| [Cross-Schema Composition](cross-schema-composition/) | v0.1.1 (2026-05-04) | Outline + §3 + §4 substantive (deferred) | Typed attestation references with slashing-aware proof propagation; v2 protocol territory pending design-partner validation |
-| [Native Delegation](native-delegation/) | v0.1.1 (2026-05-04) | Outline + §5 substantive | Hot-key / master-key separation as a runtime primitive; foundation for the Iris MCP relayer |
-| [Time-Locked Attestations](time-locked-attestations/) | v0.1.1 (2026-05-04) | Outline + §4 substantive (deferred) | Commit-reveal as a runtime primitive; sealed-bid auctions, embargoed announcements, regulatory time-locks; v1.5 territory pending design-partner validation |
-| [Verifiable Content Provenance](verifiable-content-provenance/) | v0.0 (2026-05-05) | Planning | Detection, embedding, and watermarking for the Ligate Chain receipt layer; six-path detection model; depends on Atlas (ligate-marketing #96) |
-| [Themisra Licensing Schemas](themisra-licensing-schemas/) | v0.0 (2026-05-05) | Planning | Prompt licensing and content licensing as receipt-layer extensions under the Themisra umbrella |
+| [PoUA, Proof of Useful Attestation](poua/) | v0.9.2 (2026-05-25) | Working paper, [arXiv:2605.25844](https://arxiv.org/abs/2605.25844) | Consensus weighting primitive aligning validator influence with valid attestation work. M1-M7 simulator integration; all load-bearing claims have published figures and test vectors. |
+| [Per-Schema Fee Markets](per-schema-fees/) | v0.2 (2026-05-25) | Substantive draft | EIP-1559-style demand curves per attestation schema, with PoUA-coupled base-fee burn and a KL-divergence cheating detector at 100% TPR / 1% FPR. |
+| [Cross-Schema Composition](cross-schema-composition/) | v0.2 (2026-05-25) | Substantive draft | Typed attestation references with slashing-aware proof propagation. v2 protocol territory pending design-partner validation. |
+| [Native Delegation](native-delegation/) | v0.2 (2026-05-25) | Substantive draft | Hot-key / master-key separation as a runtime primitive; foundation for the Iris MCP relayer. Theorem 1 satisfying region empirically validated with the $(w_m, w_h) = (0.7, 0.3)$ recommended operating point. |
+| [Time-Locked Attestations](time-locked-attestations/) | v0.2 (2026-05-25) | Substantive draft | Commit-reveal as a runtime primitive; sealed-bid auctions, embargoed announcements, regulatory time-locks. v1.5 territory pending design-partner validation. |
+| [Verifiable Content Provenance](verifiable-content-provenance/) | v0.2 (2026-05-27) | Substantive draft | Detection, embedding, and watermarking for the Ligate Chain receipt layer; six-path detection model with quantitative per-path coverage matrix. Depends on Atlas (ligate-marketing #96). |
+| [Themisra Licensing Schemas](themisra-licensing-schemas/) | v0.2 (2026-05-27) | Substantive draft | Prompt licensing and content licensing as receipt-layer extensions under the Themisra umbrella; 25/35/30/10 royalty split (burn/attestor/creator/builder); worked Alice/Bob creator-economy example. |
 
-PoUA v0.7 is the empirical-validation milestone: every load-bearing claim has a published figure produced by the [reference simulator](../prototypes/poua-sim/), and cross-language test vectors at [`prototypes/poua-sim/test_vectors/`](../prototypes/poua-sim/test_vectors/) encode the analytical truths so the production implementation can re-validate the algebra in lockstep.
+PoUA v0.9.2 is the empirical-validation milestone: every load-bearing claim has a published figure produced by the [reference simulator](../prototypes/poua-sim/), and cross-language test vectors at [`prototypes/poua-sim/test_vectors/`](../prototypes/poua-sim/test_vectors/) encode the analytical truths so the production implementation can re-validate the algebra in lockstep. The native-delegation and per-schema-fees simulators follow the same discipline.
 
-## Other research tracks
+## Other protocol-primitive research
 
-Papers outside the canonical protocol-primitive sequence.
+Papers that specify additional runtime primitives outside the canonical receipt-layer sequence.
 
 | Paper | Latest | Status | Topic |
 |---|---|---|---|
-| [Native DA Layer](native-da/) | v0.1.1 (2026-05-04) | Outline + §3 substantive | Attestation-optimized data availability (post-Celestia track); per-schema indexed commitments, attestor-history queries. Explicitly not advocacy for migration; documents the option. |
-| [Schema-Bound Tokens](schema-bound-tokens/) | v0.1 (2026-05-19) | Draft, formal properties (§3) written | Attestor-set-as-mint-authority as a third user-token primitive; mint events as attestations under `chain.token-mint/v1`. Companion to [ligate-chain#286](https://github.com/ligate-io/ligate-chain/issues/286). |
+| [Native DA Layer](native-da/) | v0.2 (2026-05-25) | Substantive draft | Attestation-optimized data availability (post-Celestia track); per-schema indexed commitments, attestor-history queries. Documents the migration option; does not advocate yet. |
+| [Schema-Bound Tokens](schema-bound-tokens/) | v0.2 (2026-05-25) | Substantive draft | Attestor-set-as-mint-authority as a third user-token primitive; mint events as attestations under `chain.token-mint/v1`. Companion to [ligate-chain#286](https://github.com/ligate-io/ligate-chain/issues/286). |
+| [Cross-Chain Attestation Portability](cross-chain-portability/) | v0.2 (2026-05-27) | Substantive draft | Unified IBC-style light-client proof primitive consolidating the five cross-chain extensions previously referenced from native-delegation, per-schema-fees, cross-schema-composition, time-locked-attestations, and native-da. Closes [#136](https://github.com/ligate-io/ligate-research/issues/136). |
+
+## Economics
+
+| Paper | Latest | Status | Topic |
+|---|---|---|---|
+| [AVOW Tokenomics](tokenomics/) | v0.4 (2026-05-27) | Substantive draft + Appendix B sensitivity tables | Bootstrap block reward, fee-coupled burn, path to fee-driven steady state. Appendix B sweeps four parameter dimensions (initial $R_b$, decay shape, phase-out threshold, steady-state $\tau_{\text{burn}}$) and identifies the cross-dimensional safe region for the 1B `$AVOW` supply ceiling. |
+
+## Comparisons and integrations
+
+Papers situating Ligate Chain against neighboring systems or specifying how external primitives compose with the chain.
+
+| Paper | Latest | Status | Topic |
+|---|---|---|---|
+| [EAS Comparison](eas-comparison/) | v0.2 (2026-05-27) | Substantive draft | Six-axis comparison with the Ethereum Attestation Service: trust root, fee market, schema mutability, slashing, composition, portability. Comparison table populated with citations to documented EAS behavior. |
+| [C2PA Co-existence](c2pa-composition/) | v0.2 (2026-05-27) | Substantive draft | Chain attestation as adversarially-robust companion to platform metadata. Four-gap complementarity analysis (supply/demand, strip-resistance, trust-root, compliance); chain-side C2PA trust list mirror. |
+| [TEE Composition](tee-composition/) | v0.2 (2026-05-27) | Substantive draft | Hardware attestation as typed input to chain attestations. Side-channel attack catalog with peer-reviewed citations (Foreshadow, Plundervolt, SGAxe, ÆPIC Leak, Downfall, TDX-side-channels); nonce-binding spec. |
+| [PQ Migration](pq-migration/) | v0.2 (2026-05-27) | Substantive draft | Post-quantum cryptographic migration plan; NIST FIPS 204 (ML-DSA) and FIPS 205 (SLH-DSA) targets; threshold-PQ-signatures candidate paths. Includes a Lemma 1 primitive-agnosticism proof trace showing PoUA economic security survives a crypto swap. |
 
 ## Status definitions
 


### PR DESCRIPTION
## Summary

Text follow-up to #161. The previous PR refreshed the hero image and paper table; this one updates the surrounding prose so the narrative reflects the current 15-paper portfolio.

### Root `README.md`

- **Opening** now signals the actual breadth: 15 papers across consensus, delegation, fee markets, composition, time-locks, DA, schema-bound tokens, cross-chain portability, tokenomics, and four comparison or integration notes; three Python simulators; PoUA on arXiv as the foundation paper.
- **What's in scope** drops the misleading "Specification drafts" bullet (papers themselves serve that role) and adds a pointer to `papers/CONSISTENCY_REVIEW.md`.
- **What's NOT in scope** linkifies the cross-repo references.
- **Reading and contributing** adds a "where to start" orientation paragraph that groups all 15 papers by role, fixes the stale "mid-2026 onward" line, and documents the CLA assistant workflow that every PR already triggers.

### `papers/README.md`

- **Active table**: 7 rows refreshed to current versions (PoUA v0.8→v0.9.2 with the arXiv ID inline, per-schema-fees v0.1.1→v0.2, native-delegation v0.1.1→v0.2, etc). Status field switched from outline notation to substantive-draft.
- **PoUA milestone paragraph** bumped from v0.7 to v0.9.2; notes that native-delegation and per-schema-fees simulators now follow the same discipline.
- **Section restructure**: replaces "Other research tracks" with three subsections so the 6 papers previously missing have a home:
  - **Other protocol-primitive research**: native-da, schema-bound-tokens, **cross-chain-portability** (new)
  - **Economics** (new): tokenomics v0.4
  - **Comparisons and integrations** (new): EAS, C2PA, TEE, PQ

## No content drift

Each row's topic blurb mirrors the corresponding paper's own README status block. No new claims; consolidation only.

## Test plan

- [ ] Both READMEs render correctly on GitHub
- [ ] Every paper-link in both files resolves to an existing directory
- [ ] No em dashes, no `Co-Authored-By` trailer (grep clean)